### PR TITLE
Library robustness & de-slop (behavior-preserving)

### DIFF
--- a/lib/buildTauriApp.nix
+++ b/lib/buildTauriApp.nix
@@ -8,11 +8,21 @@
   version,
   src,
   frontend,
+  # Name of the compiled binary to install from target/release. Defaults to
+  # pname, but pname is the *Nix* package name while the on-disk binary is named
+  # by cargo (`[package].name` / `[[bin]]` in src-tauri/Cargo.toml). Set this
+  # explicitly whenever pname differs from the cargo bin name, otherwise the
+  # install phase fails late with "failed to locate built binary".
   binaryName ? pname,
   cargoExtraArgs ? "",
   cargoArtifacts ? null,
   extraBuildInputs ? [ ],
   extraNativeBuildInputs ? [ ],
+  # Extra tauri.conf.json keys, deep-merged OVER the managed config (caller
+  # wins). The lib manages `build.frontendDist` (set to the `frontend`
+  # derivation) and `build.beforeBuildCommand` (cleared); setting either of those
+  # here overrides them and decouples the embedded assets from `frontend`, so
+  # don't.
   extraTauriConfig ? { },
   # Closest common ancestor of `${src}/src-tauri` and any sibling crates the
   # tauri project depends on via `{ path = "..." }`. Defaults to
@@ -24,9 +34,12 @@
   # will be rejected because the two paths can't be safely related.
   cargoRoot ? null,
   # Additional fileset entries unioned into the app source only, not the deps
-  # source. Use for non-manifest inputs the app needs at compile time (SQL
-  # migrations, fixtures); keeping them out of depsSrc preserves the deps
-  # cache across content-only edits.
+  # source. Use for non-manifest, non-`.toml` inputs the app needs at compile
+  # time (SQL migrations, JSON fixtures); keeping them out of depsSrc preserves
+  # the deps cache across content-only edits. NOTE: `.toml` files anywhere under
+  # cargoRoot are always in BOTH sources (crane's commonCargoSources keeps every
+  # `.toml` for cargo tooling), so editing one still busts the deps cache and
+  # passing one here has no effect.
   extraFileset ? null,
   ...
 }@origArgs:
@@ -304,9 +317,11 @@ in
     commonArgs
     tauriConfig
     # Path of the tauri crate relative to cargoRoot ("." outside monorepo
-    # mode). Exposed so consumers can compose their own cargo args when a
-    # tool doesn't accept the injected --manifest-path (e.g. cargo-deny):
-    #   cargoExtraArgs = "--features tauri/custom-protocol --manifest-path ${tauri.tauriSubdir}/Cargo.toml"
+    # mode). Exposed so consumers can target the tauri crate from cargoRoot.
+    # cargo-deny runs as `cargo deny check` and finds the manifest from CWD, so
+    # it wants `cargoExtraArgs = ""` — the top-level `cargo` invocation rejects
+    # --features/--manifest-path. Use cargoDenyExtraArgs (or tauriSubdir) if you
+    # must point it at the tauri crate explicitly.
     tauriSubdir
     ;
   cargoArtifacts = resolvedCargoArtifacts;

--- a/lib/buildTauriApp.nix
+++ b/lib/buildTauriApp.nix
@@ -47,13 +47,14 @@
 let
   inherit (pkgs) lib;
 
-  # The attrs this lib consumes itself, stripped so they don't leak into crane's
-  # derivations. Must stay in sync with the named formals above (minus
-  # pname/version/src, which crane needs and we forward). nativeBuildInputs and
-  # buildInputs are removed here and merged back in `sharedArgs` so a caller
-  # value is appended to ours instead of silently overriding it. The phase hooks
-  # are lib-owned (the app sets them explicitly); stripping them keeps a caller
-  # value from silently taking effect in only the deps build.
+  # The attrs this lib consumes or overrides itself, stripped so they don't leak
+  # into crane's derivations: the named formals above (minus pname/version/src,
+  # which crane needs and we forward) plus the build-input and phase-hook attrs
+  # set in `sharedArgs`. nativeBuildInputs and buildInputs are removed here and
+  # merged back in so a caller value is appended to ours instead of silently
+  # overriding it; the phase hooks are lib-owned (the app sets them explicitly),
+  # and stripping them keeps a caller value from taking effect in only the deps
+  # build.
   cleanedArgs = builtins.removeAttrs origArgs [
     "frontend"
     "binaryName"

--- a/lib/buildTauriApp.nix
+++ b/lib/buildTauriApp.nix
@@ -34,6 +34,13 @@
 let
   inherit (pkgs) lib;
 
+  # The attrs this lib consumes itself, stripped so they don't leak into crane's
+  # derivations. Must stay in sync with the named formals above (minus
+  # pname/version/src, which crane needs and we forward). nativeBuildInputs and
+  # buildInputs are removed here and merged back in `sharedArgs` so a caller
+  # value is appended to ours instead of silently overriding it. The phase hooks
+  # are lib-owned (the app sets them explicitly); stripping them keeps a caller
+  # value from silently taking effect in only the deps build.
   cleanedArgs = builtins.removeAttrs origArgs [
     "frontend"
     "binaryName"
@@ -44,6 +51,11 @@ let
     "extraTauriConfig"
     "cargoRoot"
     "extraFileset"
+    "nativeBuildInputs"
+    "buildInputs"
+    "buildPhaseCargoCommand"
+    "installPhaseCommand"
+    "doInstallCargoArtifacts"
   ];
 
   tauriSrc = src + "/src-tauri";
@@ -170,24 +182,27 @@ let
   # skip injection — otherwise cargo would see two flags and silently use the
   # last one (ours), overriding the caller's choice.
   callerSetManifestPath = lib.hasInfix "--manifest-path" cargoExtraArgs;
+  # Escape the path so a space or shell metachar in an intermediate directory
+  # (cargoRoot..src-tauri) survives crane's unquoted interpolation of
+  # cargoExtraArgs into its build command. escapeShellArg is a no-op for an
+  # ordinary `src-tauri/Cargo.toml`, so the emitted string is unchanged for the
+  # common case.
   manifestPathArg = lib.optionalString (
     isMonorepo && !callerSetManifestPath
-  ) "--manifest-path ${tauriSubdir}/Cargo.toml";
+  ) "--manifest-path ${lib.escapeShellArg "${tauriSubdir}/Cargo.toml"}";
 
-  tauriBuildCargoExtraArgs = lib.concatStringsSep " " (
-    lib.filter (s: s != "") [
-      "--features tauri/custom-protocol"
-      cargoExtraArgs
-    ]
-  );
+  joinArgs = parts: lib.concatStringsSep " " (lib.filter (s: s != "") parts);
 
-  sharedCargoExtraArgs = lib.concatStringsSep " " (
-    lib.filter (s: s != "") [
-      "--features tauri/custom-protocol"
-      cargoExtraArgs
-      manifestPathArg
-    ]
-  );
+  # The two flavors differ only by the injected --manifest-path: `cargo tauri
+  # build` rejects it, every other cargo command run from cargoRoot needs it.
+  baseCargoExtraArgs = [
+    "--features tauri/custom-protocol"
+    cargoExtraArgs
+  ];
+
+  tauriBuildCargoExtraArgs = joinArgs baseCargoExtraArgs;
+
+  sharedCargoExtraArgs = joinArgs (baseCargoExtraArgs ++ [ manifestPathArg ]);
 
   # Pin crane's vendoring to the tauri crate's own Cargo.lock when one exists
   # there. In a "loose path-deps" layout each crate carries its own lockfile,
@@ -220,8 +235,12 @@ let
       inherit pname version;
       strictDeps = true;
       cargoExtraArgs = sharedCargoExtraArgs;
-      nativeBuildInputs = [ pkgs.pkg-config ] ++ extraNativeBuildInputs;
-      buildInputs = tauriBuildInputs ++ extraBuildInputs;
+      nativeBuildInputs = [
+        pkgs.pkg-config
+      ]
+      ++ (origArgs.nativeBuildInputs or [ ])
+      ++ extraNativeBuildInputs;
+      buildInputs = tauriBuildInputs ++ (origArgs.buildInputs or [ ]) ++ extraBuildInputs;
       preConfigure = lib.concatStringsSep "\n" [
         exportAbsoluteCargoTargetDir
         (cleanedArgs.preConfigure or "")


### PR DESCRIPTION
Behavior-preserving cleanups to `lib/buildTauriApp.nix` from a full code review. **No build-output change**: fixture `app`/`frontend`/`clippy`/`fmt` derivations are byte-identical (`.drvPath` unchanged vs `main`); `integration.sh` is green locally including the monorepo path.

| ID | Issue | Fix | Cache impact |
|----|-------|-----|--------------|
| **F01** | Caller `nativeBuildInputs`/`buildInputs` silently dropped (absent from `removeAttrs`, then clobbered by `sharedArgs`'s `//`) | Strip from `cleanedArgs`, **merge** into the lib's own inputs | drvPath-identical for callers that don't pass them (all current) |
| **F09** | Lib-owned phase hooks could leak into the deps build | Strip `buildPhaseCargoCommand`/`installPhaseCommand`/`doInstallCargoArtifacts` from `cleanedArgs` | drvPath-identical (no current caller passes them) |
| **F10** | Injected `--manifest-path` word-splits on a space in the path (crane interpolates `cargoExtraArgs` unquoted) | `lib.escapeShellArg` the path; no-op for ordinary `src-tauri/Cargo.toml` | drvPath-identical for the common case |
| **F22** | Duplicated `concatStringsSep`/`filter` idiom + repeated prefix list | Extract `joinArgs` + shared `baseCargoExtraArgs` | drvPath-identical (byte-identical strings) |
| **F23** | Hand-synced `removeAttrs` list with no note | Add a "why" comment | n/a (comment) |

### Verification
- `nix eval ./fixtures/tauri-app#packages.x86_64-linux.default.drvPath` (and `frontend`/`clippy`/`fmt`) **identical** to `main`.
- `nixfmt --check` clean.
- `tests/integration.sh` 13/13 PASS locally (incl. monorepo Test 7/8, which exercise F10's escaped manifest path and F22's `joinArgs` in monorepo mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)