### PR TITLE
CI hygiene: pin actions, add Dependabot, make root-check exercise the lib

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,11 +10,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/nix-installer-action@v22
       - run: |
           set -euo pipefail
           mkdir -p ci-logs
           nix flake check 2>&1 | tee ci-logs/root-check.log
+          # `nix flake check` does not force `lib` outputs, so a parse/eval error
+          # in buildTauriApp.nix would only surface in the fixture jobs. Force the
+          # lib import here so the root job actually exercises it.
+          nix eval --json .#lib.buildTauriApp --apply builtins.functionArgs \
+            2>&1 | tee -a ci-logs/root-check.log
       - if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
@@ -26,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/nix-installer-action@v22
       - run: |
           set -euo pipefail
           mkdir -p ci-logs
@@ -49,8 +54,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: DeterminateSystems/nix-installer-action@v22
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
       - run: |
           set -euo pipefail
           mkdir -p ci-logs
@@ -86,8 +91,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: DeterminateSystems/nix-installer-action@v22
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
       - run: |
           set -euo pipefail
           mkdir -p "ci-logs/integration-${{ matrix.os }}"


### PR DESCRIPTION
CI-only changes from a code review. No build-graph change.

| ID | Issue | Fix |
|----|-------|-----|
| **F06** | `nix-installer-action@main` (×4) and `magic-nix-cache-action@main` (×2) run unreviewed upstream code with the repo token and make the CI toolchain non-reproducible — while first-party actions are version-pinned, so the policy was inconsistent | Pinned to `@v22` / `@v14` (latest majors), matching `checkout@v6` / `upload-artifact@v7` |
| — | No mechanism to keep pins current | Added `.github/dependabot.yml` (github-actions, weekly) |
| **F25** | `root-check` ran `nix flake check`, which does **not** force `lib` outputs — a parse/eval error in `buildTauriApp.nix` would only surface in the (slower) fixture jobs | Added `nix eval .#lib.buildTauriApp --apply builtins.functionArgs` to force the import in the root job |

Verified locally: `actionlint` clean; the `nix eval` forces the import (returns `{"craneLib":false,"pkgs":false}`).

**Note (not done here, your call):** Determinate Systems sunset the magic-nix-cache free tier and now recommend [FlakeHub Cache](https://github.com/DeterminateSystems/flakehub-cache-action) (`flakehub-cache-action@v3`). Migrating cache backends is a separate infra decision (auth/setup), so this PR just pins the current action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)