### PR TITLE
Strongly-typed buildTauriApp arguments via the module system

### DIFF
--- a/lib/buildTauriApp.nix
+++ b/lib/buildTauriApp.nix
@@ -3,62 +3,128 @@
   craneLib,
 }:
 
-{
-  pname,
-  version,
-  src,
-  frontend,
-  binaryName ? pname,
-  cargoExtraArgs ? "",
-  cargoArtifacts ? null,
-  extraBuildInputs ? [ ],
-  extraNativeBuildInputs ? [ ],
-  extraTauriConfig ? { },
-  # Closest common ancestor of `${src}/src-tauri` and any sibling crates the
-  # tauri project depends on via `{ path = "..." }`. Defaults to
-  # `${src}/src-tauri`. Pick the tightest ancestor that covers the path deps —
-  # widening to the whole repo pulls every Cargo.toml/*.rs in the tree into
-  # the build inputs and inflates the deps cache. Must share the same on-disk
-  # root as `src` (i.e. derive from `src` or from the same source tree); a
-  # mix of a store-path `src` and a local-path `cargoRoot` (or vice versa)
-  # will be rejected because the two paths can't be safely related.
-  cargoRoot ? null,
-  # Additional fileset entries unioned into the app source only, not the deps
-  # source. Use for non-manifest inputs the app needs at compile time (SQL
-  # migrations, fixtures); keeping them out of depsSrc preserves the deps
-  # cache across content-only edits.
-  extraFileset ? null,
-  ...
-}@origArgs:
+# RFC prototype: the build arguments are a *module* rather than a bare attrset.
+# A plain attrset (`{ pname = ...; ... }`) is a valid module, so the common call
+# site is unchanged — it is just type-checked now. A function
+# (`{ config, ... }: { ... }`) or a list of modules also works, for composition.
+#
+# Build logic below is identical to the published version; only the argument
+# layer changed, so the produced derivation is byte-identical (drvPath verified).
+args:
 
 let
   inherit (pkgs) lib;
+  inherit (lib) types mkOption;
 
-  cleanedArgs = builtins.removeAttrs origArgs [
-    "frontend"
-    "binaryName"
-    "cargoExtraArgs"
-    "cargoArtifacts"
-    "extraBuildInputs"
-    "extraNativeBuildInputs"
-    "extraTauriConfig"
-    "cargoRoot"
-    "extraFileset"
-  ];
+  optionsModule =
+    { config, ... }:
+    {
+      options = {
+        pname = mkOption {
+          type = types.str;
+          description = "Nix package name (and default binaryName).";
+        };
+        version = mkOption {
+          type = types.str;
+          description = "Package version.";
+        };
+        src = mkOption {
+          type = types.path;
+          description = "Repo root containing src-tauri/.";
+        };
+        frontend = mkOption {
+          type = types.package;
+          description = "Built frontend assets derivation, embedded into the app.";
+        };
+        binaryName = mkOption {
+          type = types.str;
+          default = config.pname;
+          defaultText = lib.literalExpression "pname";
+          description = ''
+            Cargo binary name to install from target/release. Defaults to pname,
+            but the on-disk binary is named by cargo ([package].name in
+            src-tauri/Cargo.toml); set this when they differ.
+          '';
+        };
+        cargoExtraArgs = mkOption {
+          type = types.str;
+          default = "";
+          description = "Extra args appended to cargo invocations.";
+        };
+        cargoArtifacts = mkOption {
+          type = types.nullOr types.package;
+          default = null;
+          description = "Prebuilt crane deps cache to reuse instead of building one.";
+        };
+        cargoLock = mkOption {
+          type = types.nullOr types.path;
+          default = null;
+          description = "Explicit Cargo.lock for crane vendoring (wins over auto-detection).";
+        };
+        extraBuildInputs = mkOption {
+          type = types.listOf types.package;
+          default = [ ];
+        };
+        extraNativeBuildInputs = mkOption {
+          type = types.listOf types.package;
+          default = [ ];
+        };
+        extraTauriConfig = mkOption {
+          type = types.attrs;
+          default = { };
+          description = "Extra tauri.conf.json keys, merged over the managed config.";
+        };
+        cargoRoot = mkOption {
+          type = types.nullOr types.path;
+          default = null;
+          description = "Closest common ancestor of src-tauri/ and sibling path-dep crates.";
+        };
+        extraFileset = mkOption {
+          # filesets are an opaque lib value; `raw` stores it without inspection.
+          type = types.nullOr types.raw;
+          default = null;
+          description = "Extra app-only sources (non-.rs/.toml) needed at compile time.";
+        };
+        craneArgs = mkOption {
+          type = types.attrsOf types.anything;
+          default = { };
+          description = ''
+            Typed escape hatch for arbitrary crane / mkDerivation args (doCheck,
+            env vars, hooks, ...). Replaces the old `...`@origArgs + removeAttrs
+            passthrough, so a typo at the top level is rejected by the module
+            checker instead of silently leaking into the derivation.
+          '';
+        };
+      };
+    };
+
+  # _module.check defaults to true: an unknown top-level attribute (e.g. a typo
+  # like `pnmae` or `verison`) is rejected with a clear error, and a wrong type
+  # (e.g. `version = 1`) fails with the option path and expected type.
+  cfg =
+    (lib.evalModules {
+      modules = [ optionsModule ] ++ lib.toList args;
+    }).config;
+
+  inherit (cfg)
+    pname
+    version
+    src
+    frontend
+    binaryName
+    cargoExtraArgs
+    cargoArtifacts
+    extraBuildInputs
+    extraNativeBuildInputs
+    extraTauriConfig
+    cargoRoot
+    extraFileset
+    ;
 
   tauriSrc = src + "/src-tauri";
   actualCargoRoot = if cargoRoot != null then cargoRoot else tauriSrc;
   isMonorepo = toString actualCargoRoot != toString tauriSrc;
 
-  # Path of the tauri crate relative to cargoRoot. Used to construct
-  # `--manifest-path` for non-tauri cargo commands run from cargoRoot. Throws
-  # if a caller sets cargoRoot to something that isn't an ancestor of
-  # ${src}/src-tauri — otherwise `lib.removePrefix` would silently return the
-  # full absolute path and the build would fail confusingly downstream.
-  # The compared strings are `toString`-evaluated absolute paths, so `src`
-  # and `cargoRoot` must share the same on-disk root (both local paths or
-  # both from the same store derivation). Mixing a store-path `src` with a
-  # local `cargoRoot` (or vice versa) will hit this branch.
   tauriSubdir =
     if !isMonorepo then
       "."
@@ -159,16 +225,6 @@ let
     log_relocation "derivation=$derivationName summary files=$relocationFiles matches=$relocationMatches rewrites=$relocationRewrites"
   '';
 
-  # `cargo tauri build` rejects --manifest-path — it does its own src-tauri/
-  # discovery from CWD — but every other cargo command run from cargoRoot in
-  # monorepo mode needs --manifest-path to find the tauri Cargo.toml. So we
-  # carry two flavors of extra args. Consumers composing `commonArgs` with a
-  # tool that also rejects --manifest-path (e.g. cargo-deny) should compose
-  # their own args using the returned `tauriSubdir`.
-  #
-  # If the caller already supplied --manifest-path via `cargoExtraArgs` we
-  # skip injection — otherwise cargo would see two flags and silently use the
-  # last one (ours), overriding the caller's choice.
   callerSetManifestPath = lib.hasInfix "--manifest-path" cargoExtraArgs;
   manifestPathArg = lib.optionalString (
     isMonorepo && !callerSetManifestPath
@@ -189,33 +245,18 @@ let
     ]
   );
 
-  # Pin crane's vendoring to the tauri crate's own Cargo.lock when one exists
-  # there. In a "loose path-deps" layout each crate carries its own lockfile,
-  # and without this override crane would vendor from whichever Cargo.lock
-  # sits at the fileset root (cargoRoot) and feed the tauri build the wrong
-  # dependency set. In a true cargo workspace only the workspace root has a
-  # Cargo.lock, so we leave crane on its default (workspace lockfile at
-  # cargoRoot). A caller-supplied `cargoLock` always wins — see `sharedArgs`.
   monorepoCargoLock = lib.optionalAttrs (
     isMonorepo && builtins.pathExists (tauriSrc + "/Cargo.lock")
   ) { cargoLock = tauriSrc + "/Cargo.lock"; };
 
-  # `cargo tauri build` chdirs into ${tauriSubdir} before invoking cargo, so a
-  # relative CARGO_TARGET_DIR would resolve to different absolute paths in the
-  # deps build (CWD = cargoRoot) and the app build (CWD = cargoRoot/${tauriSubdir}).
-  # Every cached crate's fingerprint check would then fail and the deps cache
-  # would be useless. Set an absolute target dir at preConfigure so both
-  # builds share the same target/ tree.
   exportAbsoluteCargoTargetDir = lib.optionalString isMonorepo ''
     export CARGO_TARGET_DIR="$PWD/target"
   '';
 
-  # `monorepoCargoLock` is placed *before* `cleanedArgs` so a caller-supplied
-  # `cargoLock` overrides it. This is the escape hatch for layouts the auto-
-  # detect above doesn't cover.
   sharedArgs =
     monorepoCargoLock
-    // cleanedArgs
+    // lib.optionalAttrs (cfg.cargoLock != null) { cargoLock = cfg.cargoLock; }
+    // cfg.craneArgs
     // {
       inherit pname version;
       strictDeps = true;
@@ -224,7 +265,7 @@ let
       buildInputs = tauriBuildInputs ++ extraBuildInputs;
       preConfigure = lib.concatStringsSep "\n" [
         exportAbsoluteCargoTargetDir
-        (cleanedArgs.preConfigure or "")
+        (cfg.craneArgs.preConfigure or "")
         relocateCachedTauriPaths
       ];
     };
@@ -284,10 +325,6 @@ in
     frontend
     commonArgs
     tauriConfig
-    # Path of the tauri crate relative to cargoRoot ("." outside monorepo
-    # mode). Exposed so consumers can compose their own cargo args when a
-    # tool doesn't accept the injected --manifest-path (e.g. cargo-deny):
-    #   cargoExtraArgs = "--features tauri/custom-protocol --manifest-path ${tauri.tauriSubdir}/Cargo.toml"
     tauriSubdir
     ;
   cargoArtifacts = resolvedCargoArtifacts;

--- a/lib/buildTauriApp.nix
+++ b/lib/buildTauriApp.nix
@@ -3,13 +3,10 @@
   craneLib,
 }:
 
-# RFC prototype: the build arguments are a *module* rather than a bare attrset.
-# A plain attrset (`{ pname = ...; ... }`) is a valid module, so the common call
-# site is unchanged — it is just type-checked now. A function
-# (`{ config, ... }: { ... }`) or a list of modules also works, for composition.
-#
-# Build logic below is identical to the published version; only the argument
-# layer changed, so the produced derivation is byte-identical (drvPath verified).
+# Build arguments are a module: a plain attrset (`{ pname = ...; ... }`) is the
+# common form, but a function (`{ config, ... }: { ... }`) or a list of modules
+# also works. Arguments are type-checked and unknown attributes are rejected;
+# arbitrary crane / mkDerivation args go through `craneArgs`.
 args:
 
 let
@@ -30,7 +27,7 @@ let
         };
         src = mkOption {
           type = types.path;
-          description = "Repo root containing src-tauri/.";
+          description = "Repo root containing src-tauri/ (a path or store derivation).";
         };
         frontend = mkOption {
           type = types.package;
@@ -43,7 +40,8 @@ let
           description = ''
             Cargo binary name to install from target/release. Defaults to pname,
             but the on-disk binary is named by cargo ([package].name in
-            src-tauri/Cargo.toml); set this when they differ.
+            src-tauri/Cargo.toml); set this when they differ, or the install
+            phase fails late with "failed to locate built binary".
           '';
         };
         cargoExtraArgs = mkOption {
@@ -64,43 +62,66 @@ let
         extraBuildInputs = mkOption {
           type = types.listOf types.package;
           default = [ ];
+          description = "Extra buildInputs, appended to the Tauri system libraries.";
         };
         extraNativeBuildInputs = mkOption {
           type = types.listOf types.package;
           default = [ ];
+          description = "Extra nativeBuildInputs, appended to pkg-config.";
+        };
+        tauriFeatures = mkOption {
+          type = types.listOf types.str;
+          default = [ "tauri/custom-protocol" ];
+          description = ''
+            Cargo features passed via --features. Defaults to the custom-protocol
+            feature Tauri v2 release builds require; set to [ ] to omit the flag
+            entirely (e.g. when features are driven from Cargo.toml).
+          '';
         };
         extraTauriConfig = mkOption {
           type = types.attrs;
           default = { };
-          description = "Extra tauri.conf.json keys, merged over the managed config.";
+          description = ''
+            Extra tauri.conf.json keys, deep-merged with the managed config. The
+            managed build.frontendDist (the `frontend` derivation) and
+            build.beforeBuildCommand WIN over values set here, so the embedded
+            assets always track `frontend`; all other keys are caller-controlled.
+          '';
         };
         cargoRoot = mkOption {
           type = types.nullOr types.path;
           default = null;
-          description = "Closest common ancestor of src-tauri/ and sibling path-dep crates.";
+          description = ''
+            Closest common ancestor of src-tauri/ and any sibling path-dep crates.
+            Defaults to src-tauri/. Must share the same on-disk root as src.
+          '';
         };
         extraFileset = mkOption {
           # filesets are an opaque lib value; `raw` stores it without inspection.
           type = types.nullOr types.raw;
           default = null;
-          description = "Extra app-only sources (non-.rs/.toml) needed at compile time.";
+          description = ''
+            Extra app-only sources the app needs at compile time (SQL migrations,
+            JSON fixtures). Must be non-.rs and non-.toml: crane already keeps all
+            .toml in both sources, so a .toml here is redundant and still busts
+            the deps cache on edit.
+          '';
         };
         craneArgs = mkOption {
           type = types.attrsOf types.anything;
           default = { };
           description = ''
-            Typed escape hatch for arbitrary crane / mkDerivation args (doCheck,
-            env vars, hooks, ...). Replaces the old `...`@origArgs + removeAttrs
-            passthrough, so a typo at the top level is rejected by the module
-            checker instead of silently leaking into the derivation.
+            Escape hatch for arbitrary crane / mkDerivation args (doCheck, env
+            vars, hooks, ...). Use this rather than passing such args at the top
+            level, which the module checker rejects as unknown options.
           '';
         };
       };
     };
 
   # _module.check defaults to true: an unknown top-level attribute (e.g. a typo
-  # like `pnmae` or `verison`) is rejected with a clear error, and a wrong type
-  # (e.g. `version = 1`) fails with the option path and expected type.
+  # like `pnmae`) is rejected with a clear error, and a wrong type (e.g.
+  # `version = 1`) fails with the option path and expected type.
   cfg =
     (lib.evalModules {
       modules = [ optionsModule ] ++ lib.toList args;
@@ -116,6 +137,7 @@ let
     cargoArtifacts
     extraBuildInputs
     extraNativeBuildInputs
+    tauriFeatures
     extraTauriConfig
     cargoRoot
     extraFileset
@@ -125,6 +147,12 @@ let
   actualCargoRoot = if cargoRoot != null then cargoRoot else tauriSrc;
   isMonorepo = toString actualCargoRoot != toString tauriSrc;
 
+  # Path of the tauri crate relative to cargoRoot. Throws if cargoRoot isn't an
+  # ancestor of ${src}/src-tauri — otherwise lib.removePrefix would silently
+  # return the full absolute path and the build would fail confusingly. The
+  # compared strings are toString-evaluated absolute paths, so src and cargoRoot
+  # must share the same on-disk root (both local or both from the same store
+  # derivation).
   tauriSubdir =
     if !isMonorepo then
       "."
@@ -166,26 +194,24 @@ let
     );
   };
 
-  tauriBuildInputs =
-    with pkgs;
-    [
-      openssl
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isLinux [
-      webkitgtk_4_1
-      libsoup_3
-      gtk3
-      glib
-      cairo
-      pango
-      gdk-pixbuf
-      atk
-      librsvg
-      libayatana-appindicator
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      libiconv
-    ];
+  tauriBuildInputs = [
+    pkgs.openssl
+  ]
+  ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [
+    pkgs.webkitgtk_4_1
+    pkgs.libsoup_3
+    pkgs.gtk3
+    pkgs.glib
+    pkgs.cairo
+    pkgs.pango
+    pkgs.gdk-pixbuf
+    pkgs.atk
+    pkgs.librsvg
+    pkgs.libayatana-appindicator
+  ]
+  ++ lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
+    pkgs.libiconv
+  ];
 
   relocateCachedTauriPaths = ''
     derivationName="''${name:-${pname}}"
@@ -225,30 +251,47 @@ let
     log_relocation "derivation=$derivationName summary files=$relocationFiles matches=$relocationMatches rewrites=$relocationRewrites"
   '';
 
+  # `cargo tauri build` rejects --manifest-path (it discovers src-tauri/ from
+  # CWD), but every other cargo command run from cargoRoot in monorepo mode needs
+  # it. So we carry two flavors of extra args. If the caller already supplied
+  # --manifest-path via cargoExtraArgs we skip injection.
   callerSetManifestPath = lib.hasInfix "--manifest-path" cargoExtraArgs;
+
+  # escapeShellArg the path so a space/metachar in an intermediate directory
+  # survives crane's unquoted interpolation. It is a no-op for an ordinary
+  # src-tauri/Cargo.toml, so the emitted string is unchanged for the common case.
   manifestPathArg = lib.optionalString (
     isMonorepo && !callerSetManifestPath
-  ) "--manifest-path ${tauriSubdir}/Cargo.toml";
+  ) "--manifest-path ${lib.escapeShellArg "${tauriSubdir}/Cargo.toml"}";
 
-  tauriBuildCargoExtraArgs = lib.concatStringsSep " " (
-    lib.filter (s: s != "") [
-      "--features tauri/custom-protocol"
-      cargoExtraArgs
-    ]
-  );
+  tauriFeaturesArg = lib.optionalString (
+    tauriFeatures != [ ]
+  ) "--features ${lib.concatStringsSep "," tauriFeatures}";
 
-  sharedCargoExtraArgs = lib.concatStringsSep " " (
-    lib.filter (s: s != "") [
-      "--features tauri/custom-protocol"
-      cargoExtraArgs
-      manifestPathArg
-    ]
-  );
+  joinArgs = parts: lib.concatStringsSep " " (lib.filter (s: s != "") parts);
 
+  # The two flavors differ only by the injected --manifest-path.
+  baseCargoExtraArgs = [
+    tauriFeaturesArg
+    cargoExtraArgs
+  ];
+
+  tauriBuildCargoExtraArgs = joinArgs baseCargoExtraArgs;
+
+  sharedCargoExtraArgs = joinArgs (baseCargoExtraArgs ++ [ manifestPathArg ]);
+
+  # Pin crane's vendoring to the tauri crate's own Cargo.lock when one exists
+  # there (the "loose path-deps" layout). In a true cargo workspace only the
+  # workspace root has a Cargo.lock, so we leave crane on its default. A
+  # caller-supplied cargoLock always wins — see sharedArgs.
   monorepoCargoLock = lib.optionalAttrs (
     isMonorepo && builtins.pathExists (tauriSrc + "/Cargo.lock")
   ) { cargoLock = tauriSrc + "/Cargo.lock"; };
 
+  # `cargo tauri build` chdirs into ${tauriSubdir}, so a relative
+  # CARGO_TARGET_DIR would resolve differently in the deps build (CWD =
+  # cargoRoot) and the app build, breaking every cached fingerprint. Pin an
+  # absolute target dir so both builds share one target/ tree.
   exportAbsoluteCargoTargetDir = lib.optionalString isMonorepo ''
     export CARGO_TARGET_DIR="$PWD/target"
   '';
@@ -262,8 +305,12 @@ let
       inherit pname version;
       strictDeps = true;
       cargoExtraArgs = sharedCargoExtraArgs;
-      nativeBuildInputs = [ pkgs.pkg-config ] ++ extraNativeBuildInputs;
-      buildInputs = tauriBuildInputs ++ extraBuildInputs;
+      nativeBuildInputs = [
+        pkgs.pkg-config
+      ]
+      ++ (cfg.craneArgs.nativeBuildInputs or [ ])
+      ++ extraNativeBuildInputs;
+      buildInputs = tauriBuildInputs ++ (cfg.craneArgs.buildInputs or [ ]) ++ extraBuildInputs;
       preConfigure = lib.concatStringsSep "\n" [
         exportAbsoluteCargoTargetDir
         (cfg.craneArgs.preConfigure or "")
@@ -282,12 +329,12 @@ let
       craneLib.buildDepsOnly (sharedArgs // { src = depsSrc; });
 
   tauriConfig = builtins.toJSON (
-    lib.recursiveUpdate {
+    lib.recursiveUpdate extraTauriConfig {
       build = {
         frontendDist = "${frontend}";
         beforeBuildCommand = "";
       };
-    } extraTauriConfig
+    }
   );
 
   app = craneLib.mkCargoDerivation (
@@ -326,6 +373,10 @@ in
     frontend
     commonArgs
     tauriConfig
+    # Path of the tauri crate relative to cargoRoot ("." outside monorepo mode).
+    # Exposed so consumers can target the tauri crate from cargoRoot. cargo-deny
+    # runs as `cargo deny check` and finds the manifest from CWD, so it wants
+    # cargoExtraArgs = "" (the top-level `cargo` rejects --features/--manifest-path).
     tauriSubdir
     ;
   cargoArtifacts = resolvedCargoArtifacts;

--- a/lib/buildTauriApp.nix
+++ b/lib/buildTauriApp.nix
@@ -255,8 +255,9 @@ let
 
   sharedArgs =
     monorepoCargoLock
-    // lib.optionalAttrs (cfg.cargoLock != null) { cargoLock = cfg.cargoLock; }
     // cfg.craneArgs
+    # The dedicated cargoLock option wins over any cargoLock buried in craneArgs.
+    // lib.optionalAttrs (cfg.cargoLock != null) { cargoLock = cfg.cargoLock; }
     // {
       inherit pname version;
       strictDeps = true;


### PR DESCRIPTION
Expresses `buildTauriApp`'s arguments as typed [module-system](https://nix.dev/tutorials/module-system/) options (`lib.evalModules`), and consolidates the lib improvements from #2/#7 so this is the single source of truth for `lib/buildTauriApp.nix`. **Supersedes #2 and #7** (close those once this lands).

## What it does
- **Type-checks arguments.** Typo → `error: The option 'pnmae' does not exist`; wrong type → `error: A definition for option 'version' is not of type 'string'`. (Previously both slipped through `...@origArgs` silently.)
- **No more `removeAttrs` hand-sync** (the old F23 footgun): arbitrary crane/`mkDerivation` args go through a typed `craneArgs` option; unknown top-level attrs are rejected.
- **Self-documenting**: every option carries a type, default, and description.

## Folded-in improvements (from #2/#7)
F01 merge caller build inputs · F10 `escapeShellArg` the manifest path · F11 overridable `tauriFeatures` · F22 `joinArgs` · F26 explicit `pkgs.*` · managed `tauri.conf` `build` keys win over `extraTauriConfig`. (The cache-busting F17 dead-guard removal is intentionally **left out** to keep consumer caches warm.)

## Behavior-neutral
The call site is unchanged for valid usage (a plain attrset *is* a module), and the fixture app derivation is **byte-identical to the published version** (`drvPath mm9xmm…`) — so merging this does **not** bump any consumer's cache. `integration.sh` green (incl. monorepo).

## Migration (breaking, small)
Callers passing crane args inline (e.g. `doCheck`, env vars) move them into `craneArgs = { ... }`. Plain `buildInputs`/`nativeBuildInputs` should use `extraBuildInputs`/`extraNativeBuildInputs` (or `craneArgs`); a stray top-level one now errors loudly instead of being dropped.

## Merge plan
Merge this + #3 (docs) + #4 (CI) + #5 (tests); close #2 and #7 (folded in here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)