### PR TITLE
Opt-in cleanups: explicit pkgs, overridable features, protect managed config (stacked on #2)

### DIFF
--- a/lib/buildTauriApp.nix
+++ b/lib/buildTauriApp.nix
@@ -126,26 +126,24 @@ let
     );
   };
 
-  tauriBuildInputs =
-    with pkgs;
-    [
-      openssl
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isLinux [
-      webkitgtk_4_1
-      libsoup_3
-      gtk3
-      glib
-      cairo
-      pango
-      gdk-pixbuf
-      atk
-      librsvg
-      libayatana-appindicator
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      libiconv
-    ];
+  tauriBuildInputs = [
+    pkgs.openssl
+  ]
+  ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [
+    pkgs.webkitgtk_4_1
+    pkgs.libsoup_3
+    pkgs.gtk3
+    pkgs.glib
+    pkgs.cairo
+    pkgs.pango
+    pkgs.gdk-pixbuf
+    pkgs.atk
+    pkgs.librsvg
+    pkgs.libayatana-appindicator
+  ]
+  ++ lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
+    pkgs.libiconv
+  ];
 
   relocateCachedTauriPaths = ''
     derivationName="''${name:-${pname}}"

--- a/lib/buildTauriApp.nix
+++ b/lib/buildTauriApp.nix
@@ -23,11 +23,11 @@
   # add features, or set to [ ] to omit the flag entirely (e.g. when features are
   # driven from Cargo.toml).
   tauriFeatures ? [ "tauri/custom-protocol" ],
-  # Extra tauri.conf.json keys, deep-merged OVER the managed config (caller
-  # wins). The lib manages `build.frontendDist` (set to the `frontend`
-  # derivation) and `build.beforeBuildCommand` (cleared); setting either of those
-  # here overrides them and decouples the embedded assets from `frontend`, so
-  # don't.
+  # Extra tauri.conf.json keys, deep-merged with the managed config. The lib
+  # manages `build.frontendDist` (set to the `frontend` derivation) and
+  # `build.beforeBuildCommand` (cleared), and those managed keys WIN over values
+  # set here, so the embedded assets always track `frontend`. All other keys
+  # (including other `build.*` keys) are caller-controlled.
   extraTauriConfig ? { },
   # Closest common ancestor of `${src}/src-tauri` and any sibling crates the
   # tauri project depends on via `{ path = "..." }`. Defaults to
@@ -281,12 +281,12 @@ let
       craneLib.buildDepsOnly (sharedArgs // { src = depsSrc; });
 
   tauriConfig = builtins.toJSON (
-    lib.recursiveUpdate {
+    lib.recursiveUpdate extraTauriConfig {
       build = {
         frontendDist = "${frontend}";
         beforeBuildCommand = "";
       };
-    } extraTauriConfig
+    }
   );
 
   app = craneLib.mkCargoDerivation (

--- a/lib/buildTauriApp.nix
+++ b/lib/buildTauriApp.nix
@@ -176,7 +176,7 @@ let
 
         relocationMatches=$((relocationMatches + 1))
 
-        if [ -n "$oldSourceRoot" ] && [ "$oldSourceRoot" != "$PWD" ] && grep -Fq "$oldSourceRoot" "$file"; then
+        if [ "$oldSourceRoot" != "$PWD" ] && grep -Fq "$oldSourceRoot" "$file"; then
           substituteInPlace "$file" --replace-fail "$oldSourceRoot" "$PWD"
           relocationRewrites=$((relocationRewrites + 1))
           log_relocation "derivation=$derivationName file=$file old_root=$oldSourceRoot new_root=$PWD"

--- a/lib/buildTauriApp.nix
+++ b/lib/buildTauriApp.nix
@@ -18,6 +18,11 @@
   cargoArtifacts ? null,
   extraBuildInputs ? [ ],
   extraNativeBuildInputs ? [ ],
+  # Cargo features passed as `--features` to every cargo invocation. Defaults to
+  # the custom-protocol feature that Tauri v2 release builds require; override to
+  # add features, or set to [ ] to omit the flag entirely (e.g. when features are
+  # driven from Cargo.toml).
+  tauriFeatures ? [ "tauri/custom-protocol" ],
   # Extra tauri.conf.json keys, deep-merged OVER the managed config (caller
   # wins). The lib manages `build.frontendDist` (set to the `frontend`
   # derivation) and `build.beforeBuildCommand` (cleared); setting either of those
@@ -62,6 +67,7 @@ let
     "cargoArtifacts"
     "extraBuildInputs"
     "extraNativeBuildInputs"
+    "tauriFeatures"
     "extraTauriConfig"
     "cargoRoot"
     "extraFileset"
@@ -205,10 +211,14 @@ let
 
   joinArgs = parts: lib.concatStringsSep " " (lib.filter (s: s != "") parts);
 
+  tauriFeaturesArg = lib.optionalString (
+    tauriFeatures != [ ]
+  ) "--features ${lib.concatStringsSep "," tauriFeatures}";
+
   # The two flavors differ only by the injected --manifest-path: `cargo tauri
   # build` rejects it, every other cargo command run from cargoRoot needs it.
   baseCargoExtraArgs = [
-    "--features tauri/custom-protocol"
+    tauriFeaturesArg
     cargoExtraArgs
   ];
 


### PR DESCRIPTION
The cleanups held back from #2 because they either change semantics or bump the cache. **Stacked on #2** (base = `review/lib-robustness`), so this diff shows only the incremental changes. Each is its own cherry-pickable commit, labeled by impact. Validated: fixture app/clippy/fmt drvPaths as expected, `integration.sh` 13/13 PASS locally.

| Commit | Change | Cache/behavior impact |
|--------|--------|-----------------------|
| `refactor(lib)` **F26** | `with pkgs;` → explicit `pkgs.*` in `tauriBuildInputs` | 🟢 drvPath-identical (verified) |
| `feat(lib)` **F11** | `tauriFeatures ? [ "tauri/custom-protocol" ]` (overridable; `[ ]` omits the flag) | 🟢 drvPath-identical — default reproduces the exact string |
| `fix(lib)` | `extraTauriConfig`: managed `build.frontendDist`/`beforeBuildCommand` now **win** over caller values, so embedded assets always track `frontend` | 🟢 drvPath-identical for consumers that don't override `build.*`; semantic change otherwise |
| `cleanup(lib)` **F17** | drop the provably-dead `[ -n "$oldSourceRoot" ]` relocation guard | 🟡 **one-time cache bump** (edits the build script); relocation output unchanged |

Only the last commit invalidates the deps cache (once). Since there's effectively a single consumer, that's bounded — drop that commit if you'd rather keep the cache warm.

Deliberately **not** included (documented in the review as leave-as-is): the other relocation nits (F18/F19), `--locked` (F15, build-break risk), and the breaking `frontend`-output removal (F24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)