### PR TITLE
buildTauriApp: use parts of cargo-tauri.hook to allow proper usage of tauri's bundle feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,6 @@ nix flake init -t github:JPHutchins/crane-tauri
 - `tauri.cargoArtifacts` is the reusable crane dependency cache derivation
 - `tauri.commonArgs`, `tauri.tauriConfig`, and `tauri.tauriSubdir` are exposed
   for composing extra checks (clippy, deny) against the same source and config
-- `binaryName` defaults to `pname`, but the installed binary is named by cargo
-  (`[package].name` in `src-tauri/Cargo.toml`). Set `binaryName` when they
-  differ, or the build fails at the install step with `failed to locate built
-  binary`
 - to add system dependencies, pass `extraNativeBuildInputs` / `extraBuildInputs`
   (appended to `pkg-config` and the Tauri system libraries); other crane /
   `mkDerivation` args go via `craneArgs`

--- a/lib/buildTauriApp.nix
+++ b/lib/buildTauriApp.nix
@@ -19,7 +19,7 @@ let
       options = {
         pname = mkOption {
           type = types.str;
-          description = "Nix package name (and default binaryName).";
+          description = "Nix package name.";
         };
         version = mkOption {
           type = types.str;
@@ -32,17 +32,6 @@ let
         frontend = mkOption {
           type = types.package;
           description = "Built frontend assets derivation, embedded into the app.";
-        };
-        binaryName = mkOption {
-          type = types.str;
-          default = config.pname;
-          defaultText = lib.literalExpression "pname";
-          description = ''
-            Cargo binary name to install from target/release. Defaults to pname,
-            but the on-disk binary is named by cargo ([package].name in
-            src-tauri/Cargo.toml); set this when they differ, or the install
-            phase fails late with "failed to locate built binary".
-          '';
         };
         cargoExtraArgs = mkOption {
           type = types.str;
@@ -132,7 +121,6 @@ let
     version
     src
     frontend
-    binaryName
     cargoExtraArgs
     cargoArtifacts
     extraBuildInputs

--- a/lib/buildTauriApp.nix
+++ b/lib/buildTauriApp.nix
@@ -344,7 +344,18 @@ let
             --config "$TAURI_CONFIG"
         '';
 
-      installPhaseCommand = pkgs.cargo-tauri.hook.installScript;
+      installPhaseCommand =
+        lib.optionalString pkgs.stdenv.hostPlatform.isDarwin
+          # Needing to install binaries when there's already a .app
+          # especially for something with a GUI feels wrong to me.
+          # But I don't know anything about MacOS so maybe I'm wrong
+
+          # bash
+          ''
+            mkdir -p "$out/bin"
+            find "$targetDir" -maxdepth 1 -type f -executable -print0 | xargs -0 cp --target-directory="$out/bin"
+          ''
+        + pkgs.cargo-tauri.hook.installScript;
 
       doInstallCargoArtifacts = false;
     }

--- a/lib/buildTauriApp.nix
+++ b/lib/buildTauriApp.nix
@@ -336,6 +336,10 @@ let
 
       nativeBuildInputs = commonArgs.nativeBuildInputs ++ [ pkgs.cargo-tauri ];
 
+      preFixup =
+        (lib.optionalString (commonArgs.preFixup != null && commonArgs.preFixup != "") "${commonArgs.preFixup}\n")
+        + pkgs.cargo-tauri.hook.fixupScript;
+
       buildPhaseCargoCommand =
         # bash
         ''

--- a/lib/buildTauriApp.nix
+++ b/lib/buildTauriApp.nix
@@ -340,28 +340,23 @@ let
   app = craneLib.mkCargoDerivation (
     commonArgs
     // {
+      # see: https://github.com/NixOS/nixpkgs/blob/f13ff45afd1bb73e640eaa08a7066dbed07e3238/pkgs/by-name/ca/cargo-tauri/hook.nix
+
       cargoArtifacts = resolvedCargoArtifacts;
       TAURI_CONFIG = tauriConfig;
+      targetDir = "target/release";
 
       nativeBuildInputs = commonArgs.nativeBuildInputs ++ [ pkgs.cargo-tauri ];
 
-      buildPhaseCargoCommand = ''
-        cargo tauri build --no-bundle \
-          ${tauriBuildCargoExtraArgs} \
-          --config "$TAURI_CONFIG"
-      '';
+      buildPhaseCargoCommand =
+        # bash
+        ''
+          cargo tauri build -b ${pkgs.cargo-tauri.hook.defaultTauriBundleType} \
+            ${tauriBuildCargoExtraArgs} \
+            --config "$TAURI_CONFIG"
+        '';
 
-      installPhaseCommand = ''
-        binaryPath=$(find target -type f -path ${lib.escapeShellArg "*/release/${binaryName}"} -print -quit)
-
-        if [ -z "$binaryPath" ]; then
-          echo "failed to locate built binary ${binaryName}" >&2
-          exit 1
-        fi
-
-        mkdir -p $out/bin
-        cp "$binaryPath" $out/bin/
-      '';
+      installPhaseCommand = pkgs.cargo-tauri.hook.installScript;
 
       doInstallCargoArtifacts = false;
     }


### PR DESCRIPTION
This allows for things configured in the bundler, such as `.desktop` entries to actually show up in the `app` derivation. The only other thing from `cargo-tauri.hook` that we may still want to add is the [`fixupScript`](https://github.com/NixOS/nixpkgs/blob/f13ff45afd1bb73e640eaa08a7066dbed07e3238/pkgs/by-name/ca/cargo-tauri/hook.nix#L39-L48), although I can't personally figure out where that'd go.

Additionally: removes `binaryName` as it's no longer needed