### PR TITLE
fix: keep app phase commands out of the deps derivation

### DIFF
--- a/.github/workflows/review.yaml
+++ b/.github/workflows/review.yaml
@@ -18,7 +18,7 @@ jobs:
       github.event.workflow_run.event == 'pull_request' &&
       (github.event.workflow_run.conclusion == 'success' ||
        github.event.workflow_run.conclusion == 'failure')
-    uses: JPHutchins/code-review/.github/workflows/review-reusable.yaml@v0.1.0-alpha.40
+    uses: JPHutchins/code-review/.github/workflows/review-reusable.yaml@v0.1.0-alpha.47
     with:
       head_sha:      ${{ github.event.workflow_run.head_sha }}
       head_branch:   ${{ github.event.workflow_run.head_branch }}
@@ -27,8 +27,13 @@ jobs:
       conclusion:    ${{ github.event.workflow_run.conclusion }}
       trigger_event: ${{ github.event.workflow_run.event }}
       api_base_url:  ${{ vars.API_BASE_URL }}
-      model_full:    deepseek-v4-flash
-      model_mechanic: deepseek-v4-flash
+      model_full:    deepseek-v4-pro
+      model_mechanic: deepseek-v4-pro
+      # The tier aliases the agent's own internal model picks resolve to. Left unset they follow the
+      # route models above, which would put every pick on pro; naming them keeps the cheap tiers
+      # cheap. haiku especially: it inherits model_mechanic, and that is pro now.
+      sonnet_model:  deepseek-v4-flash
+      haiku_model:   deepseek-v4-flash
       scope:         ${{ vars.SCOPE }}   # empty ⇒ the reviewer infers scope from the README's first paragraph (#139)
       mechanic_time_limit: 3m
       mechanic_grace_period: 90s

--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ nix flake init -t github:JPHutchins/crane-tauri
 - to add system dependencies, pass `extraNativeBuildInputs` / `extraBuildInputs`
   (appended to `pkg-config` and the Tauri system libraries); other crane /
   `mkDerivation` args go via `craneArgs`
+- phase/install-shaping `craneArgs` keys (`buildPhase`, `installPhase*`,
+  `checkPhase*`, `buildCommand`, `phases`, `dont*`, ...) are stripped before
+  the deps build and from `tauri.commonArgs`, so they cannot replace the
+  dependency build or hollow out a composed check; customise the deps build
+  via `cargoArtifactsArgs`, which is applied to `buildDepsOnly` and honors
+  crane's `buildPhaseCargoCommand` there
 - `tauri/custom-protocol` is injected by default (required for Tauri v2 release
   builds); override the feature set via `tauriFeatures`, and your
   `cargoExtraArgs` is appended

--- a/lib/buildTauriApp.nix
+++ b/lib/buildTauriApp.nix
@@ -322,11 +322,32 @@ let
     src = appSrc;
   };
 
+  # Keys that describe how to build and install the *app*. They must not reach
+  # buildDepsOnly: crane honors a caller-supplied buildPhaseCargoCommand /
+  # installPhaseCommand there, and mkCargoDerivation honors buildPhase /
+  # installPhase ahead of either. Left in sharedArgs they replace the dependency
+  # build with the app's commands, so the deps derivation succeeds having
+  # compiled nothing and the cache it publishes is empty.
+  appOnlyCraneKeys = [
+    "buildPhase"
+    "buildPhaseCargoCommand"
+    "checkPhase"
+    "checkPhaseCargoCommand"
+    "doInstallCargoArtifacts"
+    "fixupPhase"
+    "installPhase"
+    "installPhaseCommand"
+    "meta"
+    "outputs"
+    "postInstall"
+    "preFixup"
+  ];
+
   resolvedCargoArtifacts =
     if cargoArtifacts != null then
       cargoArtifacts
     else
-      craneLib.buildDepsOnly (sharedArgs // { src = depsSrc; });
+      craneLib.buildDepsOnly ((builtins.removeAttrs sharedArgs appOnlyCraneKeys) // { src = depsSrc; });
 
   tauriConfig = builtins.toJSON (
     lib.recursiveUpdate extraTauriConfig {

--- a/lib/buildTauriApp.nix
+++ b/lib/buildTauriApp.nix
@@ -328,7 +328,13 @@ let
   # installPhase ahead of either. Left in sharedArgs they replace the dependency
   # build with the app's commands, so the deps derivation succeeds having
   # compiled nothing and the cache it publishes is empty.
+  # buildCommand, buildCommandPath and phases are the stdenv-level equivalents:
+  # genericBuild sources/evals the first two and returns before the phase list is
+  # ever built, and phases can simply omit buildPhase — so any of them replaces
+  # the dependency build just as effectively as the crane-level keys above.
   appOnlyCraneKeys = [
+    "buildCommand"
+    "buildCommandPath"
     "buildPhase"
     "buildPhaseCargoCommand"
     "checkPhase"
@@ -339,6 +345,7 @@ let
     "installPhaseCommand"
     "meta"
     "outputs"
+    "phases"
     "postInstall"
     "preFixup"
   ];

--- a/lib/buildTauriApp.nix
+++ b/lib/buildTauriApp.nix
@@ -114,6 +114,18 @@ let
             Escape hatch for arbitrary crane / mkDerivation args (doCheck, env
             vars, hooks, ...). Use this rather than passing such args at the top
             level, which the module checker rejects as unknown options.
+            Phase/install-shaping keys are stripped before the deps build and
+            from commonArgs — customise the deps build via cargoArtifactsArgs.
+          '';
+        };
+        cargoArtifactsArgs = mkOption {
+          type = types.attrsOf types.anything;
+          default = { };
+          description = ''
+            crane / mkDerivation args applied to the cargoArtifacts (deps)
+            derivation only, merged after the app-phase keys are stripped. The
+            explicit channel for customising the dependency build — crane
+            honors e.g. buildPhaseCargoCommand there.
           '';
         };
       };
@@ -135,6 +147,7 @@ let
     binaryName
     cargoExtraArgs
     cargoArtifacts
+    cargoArtifactsArgs
     extraBuildInputs
     extraNativeBuildInputs
     tauriFeatures
@@ -318,10 +331,6 @@ let
       ];
     };
 
-  commonArgs = sharedArgs // {
-    src = appSrc;
-  };
-
   # Keys that describe how to build and install the *app*. They must not reach
   # buildDepsOnly: crane honors a caller-supplied buildPhaseCargoCommand /
   # installPhaseCommand there, and mkCargoDerivation honors buildPhase /
@@ -330,16 +339,31 @@ let
   # compiled nothing and the cache it publishes is empty.
   # buildCommand, buildCommandPath and phases are the stdenv-level equivalents:
   # genericBuild sources/evals the first two and returns before the phase list is
-  # ever built, and phases can simply omit buildPhase — so any of them replaces
-  # the dependency build just as effectively as the crane-level keys above.
+  # ever built, and phases can simply omit buildPhase. The dont* flags have the
+  # same effect per phase — genericBuild's phase loop skips any phase whose
+  # dont* flag is set — and buildDepsOnly force-sets doInstallCargoArtifacts, so
+  # an empty target dir is still published. cargoBuildCommand / cargoCheckCommand
+  # are crane's command slots: buildDepsOnly's default buildPhaseCargoCommand
+  # interpolates them, so a non-building value empties the cache the same way.
   appOnlyCraneKeys = [
     "buildCommand"
     "buildCommandPath"
     "buildPhase"
     "buildPhaseCargoCommand"
+    "cargoBuildCommand"
+    "cargoCheckCommand"
+    "cargoTestCommand"
     "checkPhase"
     "checkPhaseCargoCommand"
     "doInstallCargoArtifacts"
+    "dontBuild"
+    "dontCheck"
+    "dontConfigure"
+    "dontDist"
+    "dontFixup"
+    "dontInstall"
+    "dontPatch"
+    "dontUnpack"
     "fixupPhase"
     "installPhase"
     "installPhaseCommand"
@@ -350,11 +374,27 @@ let
     "preFixup"
   ];
 
+  appArgs = sharedArgs // {
+    src = appSrc;
+  };
+
+  # The public attrset consumers derive their checks from (the README's clippy
+  # recipe). Stripped of the same keys: a checks derivation honors buildCommand /
+  # phases / buildPhase exactly like buildDepsOnly does, so a composed check
+  # could pass having compiled nothing.
+  commonArgs = builtins.removeAttrs appArgs appOnlyCraneKeys;
+
   resolvedCargoArtifacts =
     if cargoArtifacts != null then
       cargoArtifacts
     else
-      craneLib.buildDepsOnly ((builtins.removeAttrs sharedArgs appOnlyCraneKeys) // { src = depsSrc; });
+      craneLib.buildDepsOnly (
+        (builtins.removeAttrs sharedArgs appOnlyCraneKeys)
+        // {
+          src = depsSrc;
+        }
+        // cfg.cargoArtifactsArgs
+      );
 
   tauriConfig = builtins.toJSON (
     lib.recursiveUpdate extraTauriConfig {
@@ -366,12 +406,12 @@ let
   );
 
   app = craneLib.mkCargoDerivation (
-    commonArgs
+    appArgs
     // {
       cargoArtifacts = resolvedCargoArtifacts;
       TAURI_CONFIG = tauriConfig;
 
-      nativeBuildInputs = commonArgs.nativeBuildInputs ++ [ pkgs.cargo-tauri ];
+      nativeBuildInputs = appArgs.nativeBuildInputs ++ [ pkgs.cargo-tauri ];
 
       buildPhaseCargoCommand = ''
         cargo tauri build --no-bundle \

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -437,9 +437,17 @@ awk '
 mv flake.nix.new flake.nix
 commit_all "add craneArgs phase overrides"
 
+# Nix 2.35 wraps `derivation show` output as {version, derivations}; 2.28 emits
+# the bare drvPath->derivation map. Accept either, and skip non-object values so
+# a future top-level scalar cannot crash jq under `set -e` before the guard below
+# gets a chance to report a readable failure.
 drv_env() {
   jq -r --arg name "$1" --arg attr "$2" \
-    'to_entries[] | select(.value.env.name == $name) | .value.env[$attr] // ""'
+    '(.derivations // .)
+     | to_entries[]
+     | select((.value | type) == "object")
+     | select((.value.env.name // "") == $name)
+     | .value.env[$attr] // ""'
 }
 
 derivations_json=$(run_verbose nix derivation show -r .#default)

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -409,5 +409,76 @@ grep -qaF "EXTRA_FILESET_MARKER_v2" "$extrafileset_out/bin/tauri-app" \
   || fail "updated extraFileset marker not found in rebuilt binary"
 pass "rebuilt binary picks up the extraFileset content edit"
 
+echo "=== Test 10: craneArgs phase keys never reach the deps derivation ==="
+
+# Evaluation only — no build. Runs last because it leaves the consumer flake with
+# a deliberately broken app build phase.
+
+echo "  Adding craneArgs phase overrides to flake.nix..."
+awk '
+  /extraFileset = \.\/migrations;/ && !done {
+    print
+    print "          craneArgs = {"
+    print "            buildPhase = \"echo SENTINEL_BUILD_PHASE\";"
+    print "            buildPhaseCargoCommand = \"echo SENTINEL_CARGO_COMMAND\";"
+    print "            installPhaseCommand = \"echo SENTINEL_INSTALL_COMMAND\";"
+    print "          };"
+    done = 1
+    next
+  }
+  { print }
+  END {
+    if (!done) {
+      print "ERROR: did not find the extraFileset anchor to insert craneArgs after" > "/dev/stderr"
+      exit 1
+    }
+  }
+' flake.nix > flake.nix.new
+mv flake.nix.new flake.nix
+commit_all "add craneArgs phase overrides"
+
+drv_env() {
+  jq -r --arg name "$1" --arg attr "$2" \
+    'to_entries[] | select(.value.env.name == $name) | .value.env[$attr] // ""'
+}
+
+derivations_json=$(run_verbose nix derivation show -r .#default)
+
+app_build_phase=$(printf '%s' "$derivations_json" | drv_env "tauri-app-0.1.0" buildPhase)
+deps_build_phase=$(printf '%s' "$derivations_json" | drv_env "tauri-app-deps-0.1.0" buildPhase)
+deps_install_phase=$(printf '%s' "$derivations_json" | drv_env "tauri-app-deps-0.1.0" installPhase)
+
+# Anchors the selector: if crane ever renames the deps derivation, or the phase
+# attributes stop being plain env vars, these fail loudly instead of letting the
+# SENTINEL checks below pass vacuously against empty strings.
+if [ -n "$deps_build_phase" ] && [ -n "$deps_install_phase" ]; then
+  pass "deps derivation phases are readable from the derivation graph"
+else
+  fail "could not read phases for 'tauri-app-deps-0.1.0' — update the selector in Test 10"
+fi
+
+# Proves craneArgs still reaches the app, so the SENTINEL checks below are
+# testing that the deps args were filtered, not that nothing was passed at all.
+case "$app_build_phase" in
+*SENTINEL_BUILD_PHASE*)
+  pass "craneArgs still reaches the app derivation" ;;
+*)
+  fail "craneArgs.buildPhase did not reach the app derivation: $app_build_phase" ;;
+esac
+
+case "$deps_build_phase" in
+*cargoWithProfile*)
+  pass "deps derivation still runs crane's own build command" ;;
+*)
+  fail "deps buildPhase is not crane's default: $deps_build_phase" ;;
+esac
+
+case "$deps_build_phase$deps_install_phase" in
+*SENTINEL_*)
+  fail "craneArgs phase keys leaked into the deps derivation: $deps_build_phase $deps_install_phase" ;;
+*)
+  pass "no craneArgs phase key reached the deps derivation" ;;
+esac
+
 echo ""
 echo "=== All integration tests passed ==="

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -412,7 +412,7 @@ pass "rebuilt binary picks up the extraFileset content edit"
 echo "=== Test 10: craneArgs phase keys never reach the deps derivation ==="
 
 # Evaluation only — no build. Runs last because it leaves the consumer flake with
-# a deliberately broken app build phase.
+# a deliberately broken app build.
 
 echo "  Adding craneArgs phase overrides to flake.nix..."
 awk '
@@ -422,6 +422,9 @@ awk '
     print "            buildPhase = \"echo SENTINEL_BUILD_PHASE\";"
     print "            buildPhaseCargoCommand = \"echo SENTINEL_CARGO_COMMAND\";"
     print "            installPhaseCommand = \"echo SENTINEL_INSTALL_COMMAND\";"
+    print "            checkPhaseCargoCommand = \"echo SENTINEL_CHECK_COMMAND\";"
+    print "            buildCommand = \"echo SENTINEL_BUILD_COMMAND\";"
+    print "            phases = \"unpackPhase patchPhase installPhase\";"
     print "          };"
     done = 1
     next
@@ -437,36 +440,39 @@ awk '
 mv flake.nix.new flake.nix
 commit_all "add craneArgs phase overrides"
 
+# Read one named flake output rather than the whole recursive closure: it avoids
+# materialising every derivation the app depends on, and it anchors the deps
+# derivation by its flake attr instead of a hard-coded name/version string.
+#
 # Nix 2.35 wraps `derivation show` output as {version, derivations}; 2.28 emits
-# the bare drvPath->derivation map. Accept either, and skip non-object values so
-# a future top-level scalar cannot crash jq under `set -e` before the guard below
-# gets a chance to report a readable failure.
+# the bare drvPath->derivation map. `(.derivations // .)` accepts either, and the
+# two `error` branches turn a further shape change into a readable message rather
+# than a jq stack trace, since `set -e` aborts on either.
 drv_env() {
-  jq -r --arg name "$1" --arg attr "$2" \
-    '(.derivations // .)
-     | to_entries[]
-     | select((.value | type) == "object")
-     | select((.value.env.name // "") == $name)
-     | .value.env[$attr] // ""'
+  run_verbose nix derivation show ".#$1" | jq -r --arg attr "$2" '
+    (if type == "object" then . else error("derivation show did not return an object") end)
+    | (.derivations // .)
+    | to_entries
+    | (if length == 1 then . else error("expected exactly 1 derivation, got \(length)") end)
+    | .[0].value.env[$attr] // ""'
 }
 
-derivations_json=$(run_verbose nix derivation show -r .#default)
+app_build_phase=$(drv_env default buildPhase)
+deps_build_phase=$(drv_env cargoArtifacts buildPhase)
+deps_install_phase=$(drv_env cargoArtifacts installPhase)
+deps_leaked_stdenv=$(drv_env cargoArtifacts buildCommand)$(drv_env cargoArtifacts phases)
 
-app_build_phase=$(printf '%s' "$derivations_json" | drv_env "tauri-app-0.1.0" buildPhase)
-deps_build_phase=$(printf '%s' "$derivations_json" | drv_env "tauri-app-deps-0.1.0" buildPhase)
-deps_install_phase=$(printf '%s' "$derivations_json" | drv_env "tauri-app-deps-0.1.0" installPhase)
-
-# Anchors the selector: if crane ever renames the deps derivation, or the phase
-# attributes stop being plain env vars, these fail loudly instead of letting the
-# SENTINEL checks below pass vacuously against empty strings.
+# Anchors the reader: if the phase attributes stop being plain env vars these fail
+# loudly instead of letting the SENTINEL checks below pass vacuously against empty
+# strings.
 if [ -n "$deps_build_phase" ] && [ -n "$deps_install_phase" ]; then
   pass "deps derivation phases are readable from the derivation graph"
 else
-  fail "could not read phases for 'tauri-app-deps-0.1.0' — update the selector in Test 10"
+  fail "could not read phases for the deps derivation — update drv_env in Test 10"
 fi
 
-# Proves craneArgs still reaches the app, so the SENTINEL checks below are
-# testing that the deps args were filtered, not that nothing was passed at all.
+# Proves craneArgs still reaches the app, so the SENTINEL checks below are testing
+# that the deps args were filtered, not that nothing was passed at all.
 case "$app_build_phase" in
 *SENTINEL_BUILD_PHASE*)
   pass "craneArgs still reaches the app derivation" ;;
@@ -487,6 +493,14 @@ case "$deps_build_phase$deps_install_phase" in
 *)
   pass "no craneArgs phase key reached the deps derivation" ;;
 esac
+
+# stdenv honors buildCommand and phases ahead of the phase list, so a leak here
+# skips the dependency build entirely while still publishing its artifacts cache.
+if [ -z "$deps_leaked_stdenv" ]; then
+  pass "no stdenv build-skipping key reached the deps derivation"
+else
+  fail "buildCommand/phases leaked into the deps derivation: $deps_leaked_stdenv"
+fi
 
 echo ""
 echo "=== All integration tests passed ==="

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -419,12 +419,32 @@ awk '
   /extraFileset = \.\/migrations;/ && !done {
     print
     print "          craneArgs = {"
-    print "            buildPhase = \"echo SENTINEL_BUILD_PHASE\";"
-    print "            buildPhaseCargoCommand = \"echo SENTINEL_CARGO_COMMAND\";"
-    print "            installPhaseCommand = \"echo SENTINEL_INSTALL_COMMAND\";"
-    print "            checkPhaseCargoCommand = \"echo SENTINEL_CHECK_COMMAND\";"
-    print "            buildCommand = \"echo SENTINEL_BUILD_COMMAND\";"
+    print "            buildCommand = \"echo SENTINEL_APP_BUILD_COMMAND\";"
+    print "            buildCommandPath = \"/nonexistent/SENTINEL_APP_BUILD_COMMAND_PATH\";"
+    print "            buildPhase = \"echo SENTINEL_APP_BUILD_PHASE\";"
+    print "            buildPhaseCargoCommand = \"echo SENTINEL_APP_BUILD_PHASE_CARGO\";"
+    print "            cargoBuildCommand = \"echo SENTINEL_APP_CARGO_BUILD\";"
+    print "            cargoCheckCommand = \"echo SENTINEL_APP_CARGO_CHECK\";"
+    print "            cargoTestCommand = \"echo SENTINEL_APP_CARGO_TEST\";"
+    print "            checkPhase = \"echo SENTINEL_APP_CHECK_PHASE\";"
+    print "            checkPhaseCargoCommand = \"echo SENTINEL_APP_CHECK_PHASE_CARGO\";"
+    print "            dontBuild = \"SENTINEL_APP_DONT_BUILD\";"
+    print "            dontCheck = \"SENTINEL_APP_DONT_CHECK\";"
+    print "            dontConfigure = \"SENTINEL_APP_DONT_CONFIGURE\";"
+    print "            dontDist = \"SENTINEL_APP_DONT_DIST\";"
+    print "            dontFixup = \"SENTINEL_APP_DONT_FIXUP\";"
+    print "            dontInstall = \"SENTINEL_APP_DONT_INSTALL\";"
+    print "            dontPatch = \"SENTINEL_APP_DONT_PATCH\";"
+    print "            dontUnpack = \"SENTINEL_APP_DONT_UNPACK\";"
+    print "            doInstallCargoArtifacts = false;"
+    print "            fixupPhase = \"echo SENTINEL_APP_FIXUP_PHASE\";"
+    print "            installPhase = \"echo SENTINEL_APP_INSTALL_PHASE\";"
+    print "            installPhaseCommand = \"echo SENTINEL_APP_INSTALL_PHASE_CARGO\";"
+    print "            meta.description = \"SENTINEL_APP_META\";"
+    print "            outputs = [ \"out\" \"doc\" ];"
     print "            phases = \"unpackPhase patchPhase installPhase\";"
+    print "            postInstall = \"echo SENTINEL_APP_POST_INSTALL\";"
+    print "            preFixup = \"echo SENTINEL_APP_PRE_FIXUP\";"
     print "          };"
     done = 1
     next
@@ -448,19 +468,29 @@ commit_all "add craneArgs phase overrides"
 # the bare drvPath->derivation map. `(.derivations // .)` accepts either, and the
 # two `error` branches turn a further shape change into a readable message rather
 # than a jq stack trace, since `set -e` aborts on either.
-drv_env() {
-  run_verbose nix derivation show ".#$1" | jq -r --arg attr "$2" '
+#
+# Each derivation is evaluated once and every lookup below reads from the
+# captured JSON — the previous version spawned five `nix derivation show` runs
+# per leg, re-evaluating the consumer flake each time.
+drv_json() {
+  run_verbose nix derivation show ".#$1" | jq -c '
     (if type == "object" then . else error("derivation show did not return an object") end)
     | (.derivations // .)
     | to_entries
     | (if length == 1 then . else error("expected exactly 1 derivation, got \(length)") end)
-    | .[0].value.env[$attr] // ""'
+    | .[0].value'
 }
 
-app_build_phase=$(drv_env default buildPhase)
-deps_build_phase=$(drv_env cargoArtifacts buildPhase)
-deps_install_phase=$(drv_env cargoArtifacts installPhase)
-deps_leaked_stdenv=$(drv_env cargoArtifacts buildCommand)$(drv_env cargoArtifacts phases)
+drv_env() {
+  jq -r --arg key "$1" '.env[$key] // ""' <<<"$2"
+}
+
+app_drv=$(drv_json default)
+deps_drv=$(drv_json cargoArtifacts)
+
+app_build_phase=$(drv_env buildPhase "$app_drv")
+deps_build_phase=$(drv_env buildPhase "$deps_drv")
+deps_install_phase=$(drv_env installPhase "$deps_drv")
 
 # Anchors the reader: if the phase attributes stop being plain env vars these fail
 # loudly instead of letting the SENTINEL checks below pass vacuously against empty
@@ -468,13 +498,13 @@ deps_leaked_stdenv=$(drv_env cargoArtifacts buildCommand)$(drv_env cargoArtifact
 if [ -n "$deps_build_phase" ] && [ -n "$deps_install_phase" ]; then
   pass "deps derivation phases are readable from the derivation graph"
 else
-  fail "could not read phases for the deps derivation — update drv_env in Test 10"
+  fail "could not read phases for the deps derivation — update drv_json in Test 10"
 fi
 
 # Proves craneArgs still reaches the app, so the SENTINEL checks below are testing
 # that the deps args were filtered, not that nothing was passed at all.
 case "$app_build_phase" in
-*SENTINEL_BUILD_PHASE*)
+*SENTINEL_APP_BUILD_PHASE*)
   pass "craneArgs still reaches the app derivation" ;;
 *)
   fail "craneArgs.buildPhase did not reach the app derivation: $app_build_phase" ;;
@@ -487,20 +517,82 @@ case "$deps_build_phase" in
   fail "deps buildPhase is not crane's default: $deps_build_phase" ;;
 esac
 
-case "$deps_build_phase$deps_install_phase" in
-*SENTINEL_*)
-  fail "craneArgs phase keys leaked into the deps derivation: $deps_build_phase $deps_install_phase" ;;
-*)
-  pass "no craneArgs phase key reached the deps derivation" ;;
-esac
-
-# stdenv honors buildCommand and phases ahead of the phase list, so a leak here
-# skips the dependency build entirely while still publishing its artifacts cache.
-if [ -z "$deps_leaked_stdenv" ]; then
-  pass "no stdenv build-skipping key reached the deps derivation"
+# Every denylist key that leaks surfaces either as its own env var (dont*,
+# buildCommand, phases, ...) or spliced into an assembled phase string
+# (buildPhaseCargoCommand / cargoBuildCommand into buildPhase,
+# installPhaseCommand / postInstall into installPhase, checkPhaseCargoCommand /
+# cargoCheckCommand into checkPhase, ...), so one scan of every env value catches
+# all of them in a single assertion.
+deps_leaked_keys=$(jq -r '
+  .env | to_entries | map(select(.value | test("SENTINEL_APP_"))) | map(.key) | join(", ")
+' <<<"$deps_drv")
+if [ -z "$deps_leaked_keys" ]; then
+  pass "no craneArgs phase key reached the deps derivation"
 else
-  fail "buildCommand/phases leaked into the deps derivation: $deps_leaked_stdenv"
+  fail "craneArgs phase keys leaked into the deps derivation: $deps_leaked_keys"
 fi
+
+# buildDepsOnly force-sets doInstallCargoArtifacts = true so the cache is always
+# published, and its cleanedArgs drop `outputs` — both hold for current crane,
+# and the denylist entries keep them true for whatever crane rev a consumer
+# pins. The sentinels set the opposite values, so both assertions prove the deps
+# derivation keeps crane's own defaults.
+deps_do_install=$(drv_env doInstallCargoArtifacts "$deps_drv")
+if [ "$deps_do_install" = "1" ]; then
+  pass "deps derivation keeps crane's doInstallCargoArtifacts"
+else
+  fail "doInstallCargoArtifacts leaked into the deps derivation: $deps_do_install"
+fi
+
+# The versioned `derivation show` shape renders outputs as an object keyed by
+# output name; the flat shape as a list. Normalize to the list of names.
+deps_outputs=$(jq -c '[.outputs | if type == "array" then .[] else keys[] end] | sort' <<<"$deps_drv")
+if [ "$deps_outputs" = '["out"]' ]; then
+  pass "deps derivation keeps its single out output"
+else
+  fail "outputs leaked into the deps derivation: $deps_outputs"
+fi
+
+# meta is not an env var and `nix derivation show` does not serialize it, so
+# read it from the derivation attr instead. The sentinel above sets
+# description, so empty proves the key was stripped.
+deps_meta_description=$(run_verbose nix eval --raw --apply 'd: d.meta.description or ""' ".#packages.$SYSTEM.cargoArtifacts")
+if [ -z "$deps_meta_description" ]; then
+  pass "craneArgs meta did not reach the deps derivation"
+else
+  fail "meta leaked into the deps derivation: $deps_meta_description"
+fi
+
+echo "  Adding cargoArtifactsArgs to flake.nix..."
+awk '
+  /extraFileset = \.\/migrations;/ && !done {
+    print
+    print "          cargoArtifactsArgs = {"
+    print "            buildPhaseCargoCommand = \"echo SENTINEL_DEPS_CHANNEL\";"
+    print "          };"
+    done = 1
+    next
+  }
+  { print }
+  END {
+    if (!done) {
+      print "ERROR: did not find the extraFileset anchor to insert cargoArtifactsArgs after" > "/dev/stderr"
+      exit 1
+    }
+  }
+' flake.nix > flake.nix.new
+mv flake.nix.new flake.nix
+commit_all "add cargoArtifactsArgs deps override"
+
+deps_drv=$(drv_json cargoArtifacts)
+deps_build_phase=$(drv_env buildPhase "$deps_drv")
+
+case "$deps_build_phase" in
+*SENTINEL_DEPS_CHANNEL*)
+  pass "cargoArtifactsArgs reaches the deps derivation" ;;
+*)
+  fail "cargoArtifactsArgs.buildPhaseCargoCommand did not reach the deps build: $deps_build_phase" ;;
+esac
 
 echo ""
 echo "=== All integration tests passed ==="


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This PR was authored by claude-opus-5[1m] on behalf of @JPHutchins. JP asked me to research #11 and then implement the containment half of the plan agreed there.

Closes the silent-corruption half of #11.

`craneArgs` phase keys are ignored on the app and **applied to the deps derivation**, so a caller who sets `buildPhaseCargoCommand` gets a `-deps` build that compiles nothing and exits 0, publishing an empty artifacts cache. `craneArgs.buildPhase` clobbers both derivations. This strips those keys before `buildDepsOnly`.

**Containment only.** Making `craneArgs` actually override the *app's* build and install commands is the follow-up in #11 (the freeform-submodule redesign). This is deliberately small so it can land independently of #10 and #12.

## Evidence

Fixture with `craneArgs = { buildPhaseCargoCommand = "echo CUSTOM_CARGO_COMMAND_MARKER"; installPhaseCommand = "echo CUSTOM_INSTALL_MARKER"; }`, via `nix derivation show -r`:

```
before, tauri-app-deps-0.1.0
  buildPhase:   runHook preBuild | cargo --version | echo CUSTOM_CARGO_COMMAND_MARKER | runHook postBuild
  installPhase: runHook preInstall | echo CUSTOM_INSTALL_MARKER | runHook postInstall

after, tauri-app-deps-0.1.0
  buildPhase:   runHook preBuild | cargo --version | cargoWithProfile check --features … --all-targets
                | cargoWithProfile build --features … | runHook postBuild
  installPhase: runHook preInstall | mkdir -p $out | runHook postInstall
```

<details>
<summary>Why the two derivations diverged</summary>

`cfg.craneArgs` is merged into `sharedArgs`, which feeds both `craneLib.buildDepsOnly` and (via `commonArgs`) the app. On the app side the literals re-specified in the `app` attrset win, because `//` is right-biased. On the deps side nothing re-specified them, and crane defers to the caller ([`ipetkov/crane@2c71e19`, `lib/buildDepsOnly.nix`](https://github.com/ipetkov/crane/blob/2c71e194474d13de031d729b729c968ddbe3507f/lib/buildDepsOnly.nix)):

```nix
    # First we run `cargo check` to cache cargo's internal artifacts, fingerprints, etc. for all deps.
    # Then we run `cargo build` to actually compile the deps and cache the results
    buildPhaseCargoCommand =
      args.buildPhaseCargoCommand or ''
        ${cargoCheckCommand} ${cargoExtraArgs} ${cargoCheckExtraArgs}
        ${cargoBuildCommand} ${cargoExtraArgs} ${cargoBuildExtraArgs}
      '';
```

`buildPhase` clobbers both because `mkCargoDerivation` honours `args.buildPhase` ahead of the assembled phase in either derivation.

</details>

## No cache invalidation

The risk worth checking on a fix like this is silently rebuilding every consumer's dependency cache. It does not. For args that set none of these keys `removeAttrs` is a no-op; the pristine fixture built against a snapshot of `main`'s lib and against this branch produces byte-identical derivations:

```
main:   /nix/store/24136a4p8wksb5fz5xly3rlviv1vs3br-tauri-app-deps-0.1.0.drv
branch: /nix/store/24136a4p8wksb5fz5xly3rlviv1vs3br-tauri-app-deps-0.1.0.drv
```

Same for `p1kmiq19hwf4raxy1gsg7h4vk1vy78gm-tauri-app-0.1.0.drv`.

## Test 10

Evaluation-only, so it adds no build time to a suite that is still serial (#8).

It asserts **both** directions: the deps derivation still runs crane's own command, *and* `craneArgs` still reaches the app. Without the second assertion the first would pass vacuously if the plumbing ever stopped delivering `craneArgs` at all — the same failure mode the `-deps` naming anchor already guards against elsewhere in the suite.

<details>
<summary>Two review notes</summary>

**Test 10 must stay last.** It leaves the consumer flake with a deliberately broken app build phase, so anything placed after it would build that. Worth remembering if the suite is reordered when #8 matrices it.

**Scope of `appOnlyCraneKeys`.** `preBuild`, `preConfigure`, env vars and inputs stay shared, because consumers legitimately need them in both derivations — symlinking `[patch.crates-io]` paths into place before cargo reads the manifest is the motivating real-world case. `postInstall` is app-only on the reasoning that both derivations *build*, but only one produces an application: the deps output is a target-dir tarball, so a `postInstall` written for the app is wrong there by construction. `outputs` and `doInstallCargoArtifacts` are already handled inside crane; they are listed for defence in depth rather than necessity.

</details>

Refs #11
