### PR TITLE
feat(lib): tauri.wrappedApp with wrapGAppsHook3 (#12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ nix flake init -t github:JPHutchins/crane-tauri
 - `src` should point at the repo root that contains `src-tauri`
 - `frontend` should be the built web assets, not the source tree
 - `tauri.app` is the final binary package
+- `tauri.wrappedApp` is the same binary wrapped with `wrapGAppsHook3` (Linux;
+  passes through unchanged on macOS) so runtime lookups — pixbuf loaders,
+  GSettings schemas, GIO/TLS modules, the tauri gstreamer prefixes — resolve
+  from the Nix closure instead of ambient environment
 - `tauri.cargoArtifacts` is the reusable crane dependency cache derivation
 - `tauri.commonArgs`, `tauri.tauriConfig`, and `tauri.tauriSubdir` are exposed
   for composing extra checks (clippy, deny) against the same source and config

--- a/fixtures/tauri-app/flake.nix
+++ b/fixtures/tauri-app/flake.nix
@@ -64,6 +64,7 @@
       {
         checks = {
           inherit (tauri) app;
+          wrapped = tauri.wrappedApp;
 
           clippy = craneLib.cargoClippy (
             tauri.commonArgs

--- a/lib/buildTauriApp.nix
+++ b/lib/buildTauriApp.nix
@@ -495,6 +495,47 @@ let
       doInstallCargoArtifacts = false;
     }
   );
+
+  # wrapGAppsHook3 must not enter the cargo builds (its propagated
+  # gobject-introspection inputs can perturb PKG_CONFIG_PATH for -sys crates),
+  # so the wrapper is a separate derivation around the app (#12). It assembles
+  # the runtime lookup paths the bare binary only finds by accident today:
+  # GDK_PIXBUF_MODULE_FILE, GSETTINGS_SCHEMAS_PATH/XDG_DATA_DIRS (glib/gtk3),
+  # GIO_EXTRA_MODULES (glib-networking — TLS in the webview), and the tauri
+  # gstreamer prefixes from the fixupScript. Darwin passes the app through
+  # unchanged.
+  wrappedApp =
+    if !pkgs.stdenv.hostPlatform.isLinux then
+      app
+    else
+      pkgs.stdenv.mkDerivation {
+        inherit pname version;
+        dontUnpack = true;
+        strictDeps = true;
+        nativeBuildInputs = [ pkgs.wrapGAppsHook3 ];
+        buildInputs = [
+          pkgs.webkitgtk_4_1
+          pkgs.gtk3
+          pkgs.glib
+          pkgs.gdk-pixbuf
+          pkgs.librsvg
+          pkgs.glib-networking
+        ];
+        installPhase = ''
+          runHook preInstall
+          mkdir -p $out/bin
+          cp ${app}/bin/${binaryName} $out/bin/${binaryName}
+          chmod +w $out/bin/${binaryName}
+          runHook postInstall
+        '';
+        preFixup = ''
+          gappsWrapperArgs+=(
+            --prefix WEBKIT_GST_ALLOWED_URI_PROTOCOLS : "asset"
+            --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "${pkgs.cargo-tauri.gst-plugin}/lib/gstreamer-1.0/"
+            --set-default __NV_DISABLE_EXPLICIT_SYNC 1
+          )
+        '';
+      };
 in
 {
   inherit

--- a/lib/buildTauriApp.nix
+++ b/lib/buildTauriApp.nix
@@ -540,6 +540,7 @@ in
 {
   inherit
     app
+    wrappedApp
     frontend
     commonArgs
     tauriConfig

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -448,9 +448,13 @@ case "$SYSTEM" in
 *-darwin)
   pass "wrappedApp passes the app through unchanged on darwin" ;;
 *)
-  head -c 2 "$wrapped_out/bin/tauri-app" | grep -q '^#!' || fail "wrappedApp binary is not a wrapper script"
+  # makeWrapper emits a compiled shim (an ELF, not a shell script) that embeds
+  # the environment it sets, and moves the real binary to .tauri-app-wrapped —
+  # assert on the semantics, not the file type.
+  grep -qaFR "WEBKIT_GST_ALLOWED_URI_PROTOCOLS" "$wrapped_out/bin/tauri-app" \
+    || fail "wrappedApp wrapper does not set the gstreamer env"
   grep -qaFR "vite.svg" "$wrapped_out/bin/" || fail "wrappedApp binary lost the embedded frontend marker"
-  pass "wrappedApp binary is a wrapper script around the real ELF" ;;
+  pass "wrappedApp wraps the real ELF with the GApps environment" ;;
 esac
 
 echo "=== Test 11: tauriBuild/tauriInstall closures replace the defaults ==="

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -95,7 +95,7 @@ test -x "$app_out/bin/tauri-app" || fail "binary not found or not executable"
 pass "fixture binary builds"
 
 echo "=== Test 2: Frontend assets embedded ==="
-grep -qaF "vite.svg" "$app_out/bin/tauri-app" || fail "frontend not embedded in binary"
+grep -qaFR "vite.svg" "$app_out/bin/tauri-app" || fail "frontend not embedded in binary"
 pass "frontend assets are embedded"
 
 echo "=== Test 3: Frontend builds independently ==="
@@ -196,6 +196,7 @@ cat > "$WORKDIR/flake.nix" << 'FLAKE_NIX'
       {
         packages = {
           default = tauri.app;
+          wrapped = tauri.wrappedApp;
           cargoArtifacts = tauri.cargoArtifacts;
         };
 
@@ -223,7 +224,7 @@ capture_verbose "$BUILD1_LOG" nix build "${NIX_BUILD_ARGS[@]}" .#default
 
 consumer_out=$(run_verbose nix path-info .#default)
 test -x "$consumer_out/bin/tauri-app" || fail "consumer binary not found"
-grep -qaF "vite.svg" "$consumer_out/bin/tauri-app" || fail "consumer frontend not embedded"
+grep -qaFR "vite.svg" "$consumer_out/bin/tauri-app" || fail "consumer frontend not embedded"
 pass "fresh consumer project builds with embedded frontend"
 
 app_out_before="$consumer_out"
@@ -381,11 +382,11 @@ monorepo_out=$(run_verbose nix path-info .#default)
 test -x "$monorepo_out/bin/tauri-app" || fail "monorepo binary not found"
 pass "monorepo build with sibling path-dep produces an executable binary"
 
-grep -qaF "MONOREPO_SIBLING_MARKER" "$monorepo_out/bin/tauri-app" \
+grep -qaFR "MONOREPO_SIBLING_MARKER" "$monorepo_out/bin/tauri-app" \
   || fail "sibling-crate marker string not found in binary — sibling not linked?"
 pass "sibling-crate compiled and linked into the tauri binary"
 
-grep -qaF "EXTRA_FILESET_MARKER" "$monorepo_out/bin/tauri-app" \
+grep -qaFR "EXTRA_FILESET_MARKER" "$monorepo_out/bin/tauri-app" \
   || fail "extraFileset file not embedded — migrations/ did not reach the app build?"
 pass "extraFileset file reached the app build (include_str! marker embedded)"
 
@@ -411,7 +412,7 @@ fi
 assert_log_lacks 'tauri-app-deps-0\.1\.0\.drv' "$BUILD5_LOG" "deps derivation not rebuilt after sibling .rs change"
 
 monorepo_out_after_sibling=$(run_verbose nix path-info .#default)
-grep -qaF "MONOREPO_SIBLING_MARKER_v2" "$monorepo_out_after_sibling/bin/tauri-app" \
+grep -qaFR "MONOREPO_SIBLING_MARKER_v2" "$monorepo_out_after_sibling/bin/tauri-app" \
   || fail "updated sibling marker not found in rebuilt binary"
 pass "rebuilt binary picks up the sibling source edit"
 
@@ -435,9 +436,22 @@ fi
 assert_log_lacks 'tauri-app-deps-0\.1\.0\.drv' "$BUILD6_LOG" "deps derivation not rebuilt after extraFileset content edit"
 
 extrafileset_out=$(run_verbose nix path-info .#default)
-grep -qaF "EXTRA_FILESET_MARKER_v2" "$extrafileset_out/bin/tauri-app" \
+grep -qaFR "EXTRA_FILESET_MARKER_v2" "$extrafileset_out/bin/tauri-app" \
   || fail "updated extraFileset marker not found in rebuilt binary"
 pass "rebuilt binary picks up the extraFileset content edit"
+
+echo "=== Test 12: wrappedApp wraps the binary with the GApps environment ==="
+
+wrapped_out=$(run_verbose nix build "${NIX_BUILD_ARGS[@]}" .#wrapped --print-out-paths)
+
+case "$SYSTEM" in
+*-darwin)
+  pass "wrappedApp passes the app through unchanged on darwin" ;;
+*)
+  head -c 2 "$wrapped_out/bin/tauri-app" | grep -q '^#!' || fail "wrappedApp binary is not a wrapper script"
+  grep -qaFR "vite.svg" "$wrapped_out/bin/" || fail "wrappedApp binary lost the embedded frontend marker"
+  pass "wrappedApp binary is a wrapper script around the real ELF" ;;
+esac
 
 echo "=== Test 11: tauriBuild/tauriInstall closures replace the defaults ==="
 


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by deepseek-v4-pro on behalf of @JPHutchins. This PR replaces #18, which GitHub closed when its stacked base branch (feat/build-install-closures, now merged as part of #17) was deleted — same head, same commits, rebased on main.

A separate derivation around the app — never inside the cargo builds, where `wrapGAppsHook3`'s propagated gobject-introspection inputs could perturb `PKG_CONFIG_PATH` for `-sys` crates (`lib/buildTauriApp.nix`, `wrappedApp`):

- `nativeBuildInputs = [ pkgs.wrapGAppsHook3 ]`; `buildInputs` = the runtime-lookup set (webkitgtk_4_1, gtk3, glib, gdk-pixbuf, librsvg, glib-networking — the wrap hook assembles `GIO_EXTRA_MODULES` from these).
- `preFixup` carries the tauri gstreamer args (`WEBKIT_GST_ALLOWED_URI_PROTOCOLS`, `GST_PLUGIN_SYSTEM_PATH_1_0`, `__NV_DISABLE_EXPLICIT_SYNC`).
- Linux wraps; darwin passes `app` through unchanged. Exposed as `tauri.wrappedApp` — never as a redefined `tauri.app`.
- The wrapper is a compiled ELF shim (current nixpkgs makeWrapper), the real binary lives at `.tauri-app-wrapped`; Test 12 asserts on semantics (shim embeds the gstreamer var, marker grep finds the embedded frontend via `-R`).
- The four fixture drvPaths stay byte-identical to main (drvPath oracle).

The first review round of the closed #18 **converged** (score 0.91 ≤ 1); its advisory findings (`wrapped-app-install-layout-assumption`, `nixpkgs-attr-floor-bump`, `wrapper-drops-meta`, ...) are saved as follow-up material and several are resolved by the Step 4 rework's new default closures.

Refs #12, #10