### PR TITLE
feat(lib): bundle by default — desktop entries, icons and the binary (#10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,10 @@ nix flake init -t github:JPHutchins/crane-tauri
   `frontendDist`, `tauriSubdir`, `pname`, `version`, `binaryName`) that must
   accept `...` — the context may gain keys. A caller closure replaces the
   default rather than appending to it, and `craneArgs.buildPhase` /
-  `installPhase` still take precedence over the closures on the app
+  `installPhase` still take precedence over the closures on the app. The
+  defaults bundle (`cargo tauri build -b deb` on Linux, `-b app` on macOS)
+  and install the bundle contents — desktop entry, icons, the binary — so
+  override `tauriInstall` (and `tauriBuild`) to keep just the binary
 
   ```nix
   tauriBuild = { configFlag, cargoExtraArgs, ... }:

--- a/README.md
+++ b/README.md
@@ -110,10 +110,10 @@ nix flake init -t github:JPHutchins/crane-tauri
 - `tauri.cargoArtifacts` is the reusable crane dependency cache derivation
 - `tauri.commonArgs`, `tauri.tauriConfig`, and `tauri.tauriSubdir` are exposed
   for composing extra checks (clippy, deny) against the same source and config
-- `binaryName` defaults to `pname`, but the installed binary is named by cargo
-  (`[package].name` in `src-tauri/Cargo.toml`). Set `binaryName` when they
-  differ, or the build fails at the install step with `failed to locate built
-  binary`
+- `binaryName` defaults to `pname`, but the on-disk binary is named by cargo
+  (`[package].name` in `src-tauri/Cargo.toml`); set it when they differ. It
+  selects the macOS install's binary (and wrappedApp's copy); on Linux the
+  deb layout keeps cargo's name
 - to add system dependencies, pass `extraNativeBuildInputs` / `extraBuildInputs`
   (appended to `pkg-config` and the Tauri system libraries); other crane /
   `mkDerivation` args go via `craneArgs`

--- a/lib/buildTauriApp.nix
+++ b/lib/buildTauriApp.nix
@@ -13,6 +13,17 @@ let
   inherit (pkgs) lib;
   inherit (lib) types mkOption;
 
+  # Derived locally rather than read from pkgs.cargo-tauri.hook (a
+  # makeSetupHook substitution — reaching into it couples us to a nixpkgs
+  # implementation detail across versions).
+  defaultBundleType =
+    {
+      darwin = "app";
+      linux = "deb";
+    }
+    .${pkgs.stdenv.hostPlatform.parsed.kernel.name}
+      or (throw "crane-tauri: unsupported platform ${pkgs.stdenv.hostPlatform.parsed.kernel.name}");
+
   defaultTauriBuild =
     {
       configFlag,
@@ -20,7 +31,7 @@ let
       ...
     }:
     ''
-      cargo tauri build --no-bundle \
+      cargo tauri build -b ${defaultBundleType} \
         ${cargoExtraArgs} \
         ${configFlag}
     '';
@@ -30,17 +41,38 @@ let
       binaryName,
       ...
     }:
-    ''
-      binaryPath=$(find target -type f -path ${lib.escapeShellArg "*/release/${binaryName}"} -print -quit)
+    if pkgs.stdenv.hostPlatform.isDarwin then
+      ''
+        mkdir -p "$out/Applications"
 
-      if [ -z "$binaryPath" ]; then
-        echo "failed to locate built binary ${binaryName}" >&2
-        exit 1
-      fi
+        shopt -s nullglob
+        appBundles=(target/release/bundle/macos/*.app)
+        shopt -u nullglob
 
-      mkdir -p $out/bin
-      cp "$binaryPath" $out/bin/
-    '';
+        if [ "''${#appBundles[@]}" -eq 0 ]; then
+          echo "crane-tauri: no .app bundles found under target/release/bundle/macos" >&2
+          exit 1
+        fi
+
+        mv -- "''${appBundles[@]}" "$out/Applications/"
+
+        mkdir -p "$out/bin"
+        cp target/release/${binaryName} "$out/bin/"
+      ''
+    else
+      ''
+        shopt -s nullglob
+        bundleContents=(target/release/bundle/deb/*/data/usr/*)
+        shopt -u nullglob
+
+        if [ "''${#bundleContents[@]}" -eq 0 ]; then
+          echo "crane-tauri: no deb bundle contents found under target/release/bundle/deb" >&2
+          exit 1
+        fi
+
+        mkdir -p "$out"
+        mv -- "''${bundleContents[@]}" "$out"/
+      '';
 
   optionsModule =
     { config, ... }:
@@ -167,11 +199,11 @@ let
             Renders the `cargo tauri build` invocation as a function of the
             computed context (configFlag, cargoExtraArgs, frontendDist,
             tauriSubdir, pname, version, binaryName). The function must accept
-            `...` — the context may gain keys. Defaults to the --no-bundle
-            build. craneArgs.buildPhase / installPhase take precedence over
-            this closure on the app derivation (crane honors them ahead of the
-            assembled phase); buildPhaseCargoCommand / installPhaseCommand
-            do not.
+            `...` — the context may gain keys. Defaults to `cargo tauri build
+            -b deb|app` (the platform bundle type). craneArgs.buildPhase /
+            installPhase take precedence over this closure on the app
+            derivation (crane honors them ahead of the assembled phase);
+            buildPhaseCargoCommand / installPhaseCommand do not.
           '';
         };
         tauriInstall = mkOption {
@@ -180,8 +212,9 @@ let
           description = ''
             Renders the install phase as a function of the computed context
             (same keys as tauriBuild). The function must accept `...`.
-            Defaults to installing the built binary into $out/bin. Same
-            craneArgs precedence as tauriBuild.
+            Defaults to installing the produced bundle (deb contents on
+            Linux; the .app plus the binary on macOS). Same craneArgs
+            precedence as tauriBuild.
           '';
         };
       };

--- a/lib/buildTauriApp.nix
+++ b/lib/buildTauriApp.nix
@@ -15,14 +15,15 @@ let
 
   # Derived locally rather than read from pkgs.cargo-tauri.hook (a
   # makeSetupHook substitution — reaching into it couples us to a nixpkgs
-  # implementation detail across versions).
+  # implementation detail across versions). Falls back to deb rather than
+  # throwing: the lib must keep evaluating on platforms that never build
+  # here (the old --no-bundle default did).
   defaultBundleType =
     {
       darwin = "app";
       linux = "deb";
     }
-    .${pkgs.stdenv.hostPlatform.parsed.kernel.name}
-      or (throw "crane-tauri: unsupported platform ${pkgs.stdenv.hostPlatform.parsed.kernel.name}");
+    .${pkgs.stdenv.hostPlatform.parsed.kernel.name} or "deb";
 
   defaultTauriBuild =
     {
@@ -46,32 +47,41 @@ let
         mkdir -p "$out/Applications"
 
         shopt -s nullglob
-        appBundles=(target/release/bundle/macos/*.app)
+        appBundles=(target{,/*}/release/bundle/macos/*.app)
         shopt -u nullglob
 
         if [ "''${#appBundles[@]}" -eq 0 ]; then
-          echo "crane-tauri: no .app bundles found under target/release/bundle/macos" >&2
+          echo "crane-tauri: no .app bundles found under target{,/*}/release/bundle/macos" >&2
           exit 1
         fi
 
         mv -- "''${appBundles[@]}" "$out/Applications/"
 
+        # The binary is already inside the .app; the bin/ copy keeps the
+        # $out/bin contract consumers and wrappedApp rely on.
+        binaryPath=$(find target -type f -path "*/release/${binaryName}" -print -quit)
+        if [ -z "$binaryPath" ]; then
+          echo "failed to locate built binary ${binaryName}" >&2
+          exit 1
+        fi
         mkdir -p "$out/bin"
-        cp target/release/${binaryName} "$out/bin/"
+        cp "$binaryPath" "$out/bin/"
       ''
     else
       ''
         shopt -s nullglob
-        bundleContents=(target/release/bundle/deb/*/data/usr/*)
+        bundleContents=(target{,/*}/release/bundle/deb/*/data/usr/*)
         shopt -u nullglob
 
         if [ "''${#bundleContents[@]}" -eq 0 ]; then
-          echo "crane-tauri: no deb bundle contents found under target/release/bundle/deb" >&2
+          echo "crane-tauri: no deb bundle contents found under target{,/*}/release/bundle/deb" >&2
+          echo "  the default install expects a bundled build — override tauriBuild and" >&2
+          echo "  tauriInstall together if your app does not bundle" >&2
           exit 1
         fi
 
         mkdir -p "$out"
-        mv -- "''${bundleContents[@]}" "$out"/
+        cp -a -- "''${bundleContents[@]}" "$out"/
       '';
 
   optionsModule =
@@ -101,8 +111,9 @@ let
           description = ''
             Cargo binary name to install from target/release. Defaults to pname,
             but the on-disk binary is named by cargo ([package].name in
-            src-tauri/Cargo.toml); set this when they differ, or the install
-            phase fails late with "failed to locate built binary".
+            src-tauri/Cargo.toml); set this when they differ. Used by the
+            macOS install; on Linux the installed binary keeps cargo's name
+            from the deb layout.
           '';
         };
         cargoExtraArgs = mkOption {
@@ -556,9 +567,8 @@ let
         ];
         installPhase = ''
           runHook preInstall
-          mkdir -p $out/bin
-          cp ${app}/bin/${binaryName} $out/bin/${binaryName}
-          chmod +w $out/bin/${binaryName}
+          cp -a ${app}/. "$out"/
+          chmod +w "$out"/bin/*
           runHook postInstall
         '';
         preFixup = ''

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -233,14 +233,16 @@ deps_hash_before=$(cargo_artifacts_out_path)
 
 echo "=== Test 13: bundled outputs are installed ==="
 
+test -x "$consumer_out/bin/tauri-app" || fail "binary missing from the bundled app output"
+
 case "$SYSTEM" in
 *-darwin)
   test -d "$consumer_out/Applications/tauri-app.app" || fail "no .app bundle in the app output"
-  pass "app bundle installed into Applications/" ;;
+  pass "app bundle and binary installed" ;;
 *)
   test -n "$(find "$consumer_out/share/applications" -name '*.desktop' -print -quit)" \
     || fail "no .desktop entry in the app output"
-  pass "deb bundle contents installed (desktop entry present)" ;;
+  pass "deb bundle contents installed (desktop entry and binary present)" ;;
 esac
 
 echo "=== Test 5: Dep caching survives Rust source changes ==="
@@ -520,7 +522,7 @@ case "$app_build_phase" in
 esac
 
 case "$app_build_phase$app_install_phase" in
-*cargo\ tauri\ build*|*find\ target*)
+*cargo\ tauri\ build*|*bundle/deb*)
   fail "default closure leaked alongside the caller's: $app_build_phase $app_install_phase" ;;
 *)
   pass "default closures did not concatenate with the caller's" ;;

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -231,6 +231,18 @@ app_out_before="$consumer_out"
 
 deps_hash_before=$(cargo_artifacts_out_path)
 
+echo "=== Test 13: bundled outputs are installed ==="
+
+case "$SYSTEM" in
+*-darwin)
+  test -d "$consumer_out/Applications/tauri-app.app" || fail "no .app bundle in the app output"
+  pass "app bundle installed into Applications/" ;;
+*)
+  test -n "$(find "$consumer_out/share/applications" -name '*.desktop' -print -quit)" \
+    || fail "no .desktop entry in the app output"
+  pass "deb bundle contents installed (desktop entry present)" ;;
+esac
+
 echo "=== Test 5: Dep caching survives Rust source changes ==="
 
 echo "  Modifying Rust source..."


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This PR was authored by deepseek-v4-pro on behalf of @JPHutchins. This is Step 4 of the #10 unblocking plan JP approved: @ArtixBTW's PR #10 re-implemented on the #15 closure API, with their authorship preserved (co-author trailer).

The default `tauriBuild`/`tauriInstall` closures switch from the hand-rolled `--no-bundle` build + binary install to the bundled build every nixpkgs tauri app ships:

- **Build**: `cargo tauri build -b deb` on Linux / `-b app` on macOS — the bundle type derived from `stdenv.hostPlatform`, not from `pkgs.cargo-tauri.hook`'s `makeSetupHook` substitutions.
- **Install**: Linux moves the deb's `data/usr` contents (desktop entry, icons, the binary) into `$out` under a nullglob guard with a clear error when no bundle was produced (the review's `bundle-install-unexpanded-glob` finding on the original #10); macOS installs the `.app` into `$out/Applications` and the binary into `$out/bin`.
- **`binaryName` stays** (the original PR removed it; the review's `removed-option-breaking` finding). The context carries it for the darwin install.
- **No dependency-cache bust**: `checks.clippy`'s drvPath is byte-identical to main (it embeds `cargoArtifacts` and `commonArgs`), verified before push; only the app derivation changes, by design. Consumers who don't want bundles override the two closures — the #15 escape path.
- **Test 13** asserts the bundled outputs: `.desktop` entry on Linux, `.app` on macOS.

The remaining advisory findings from the #14/#17/#18 rounds are tracked as follow-up material (saved locally); this PR also unblocks the `wrappedApp` + bundled-layout story (#12's launch-environment rationale).

Closes #10

Co-Authored-By: ArtixBTW <44449514+ArtixBTW@users.noreply.github.com>