### PR TITLE
docs: annotate the minimal example and align it with bundle-by-default

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ nix flake init -t github:JPHutchins/crane-tauri
 				inherit (pkgs) lib;
 				craneLib = crane.mkLib pkgs;
 
+				# Your frontend, built as an ordinary Nix derivation. Its output
+				# is embedded into the tauri binary by buildTauriApp.
 				frontend = pkgs.buildNpmPackage {
 					pname = "my-app-frontend";
 					version = "0.1.0";
@@ -68,6 +70,13 @@ nix flake init -t github:JPHutchins/crane-tauri
 					'';
 				};
 
+				# buildTauriApp wires cargo/crane around `cargo tauri build`:
+				# appSrc/depsSrc splitting, artifact reuse, and — by default —
+				# bundling. The defaults build `cargo tauri build -b deb`
+				# (Linux) / `-b app` (macOS) and install the bundle contents, so
+				# `tauri.app` contains the binary plus the desktop entry and
+				# icons (Linux) or the .app plus the binary (macOS). Override
+				# tauriBuild/tauriInstall to change that (see Notes).
 				tauri = crane-tauri.lib.buildTauriApp { inherit pkgs craneLib; } {
 					pname = "my-app";
 					version = "0.1.0";
@@ -76,17 +85,26 @@ nix flake init -t github:JPHutchins/crane-tauri
 				};
 			in
 			{
-				packages.default = tauri.app;
+				packages = {
+					# The bundled app (desktop entry, icons, binary).
+					default = tauri.app;
+
+					# The same app wrapped with wrapGAppsHook3 (Linux; passes
+					# through on macOS) so runtime lookups — pixbuf loaders,
+					# GSettings schemas, GIO/TLS modules, gstreamer prefixes —
+					# resolve from the Nix closure.
+					wrapped = tauri.wrappedApp;
+				};
 
 				checks = {
 					inherit (tauri) app;
 
 					# `nix flake check` runs values under `checks`.
+					# Reusing tauri.cargoArtifacts means clippy does not rebuild
+					# all Rust dependencies.
 					clippy = craneLib.cargoClippy (
 						tauri.commonArgs
 						// {
-							# Reuse the dependency cache produced by `buildTauriApp`
-							# so clippy does not rebuild all Rust dependencies.
 							cargoArtifacts = tauri.cargoArtifacts;
 							cargoClippyExtraArgs = "--all-targets -- -D warnings";
 							TAURI_CONFIG = tauri.tauriConfig;
@@ -102,11 +120,13 @@ nix flake init -t github:JPHutchins/crane-tauri
 
 - `src` should point at the repo root that contains `src-tauri`
 - `frontend` should be the built web assets, not the source tree
-- `tauri.app` is the final binary package
-- `tauri.wrappedApp` is the same binary wrapped with `wrapGAppsHook3` (Linux;
-  passes through unchanged on macOS) so runtime lookups — pixbuf loaders,
-  GSettings schemas, GIO/TLS modules, the tauri gstreamer prefixes — resolve
-  from the Nix closure instead of ambient environment
+- `tauri.app` is the final app package — the bundled output: the binary,
+  desktop entry and icons on Linux; the `.app` plus the binary on macOS
+- `tauri.wrappedApp` is the same package wrapped with `wrapGAppsHook3`
+  (Linux; passes through unchanged on macOS) so the runtime lookups of the
+  libraries the lib declares — pixbuf loaders, GSettings schemas, GIO/TLS
+  modules, the tauri gstreamer prefixes — resolve from the Nix closure
+  instead of ambient environment
 - `tauri.cargoArtifacts` is the reusable crane dependency cache derivation
 - `tauri.commonArgs`, `tauri.tauriConfig`, and `tauri.tauriSubdir` are exposed
   for composing extra checks (clippy, deny) against the same source and config
@@ -238,7 +258,7 @@ tauri = crane-tauri.lib.buildTauriApp { inherit pkgs craneLib; } {
   (e.g. `cargoRoot = src;`) when the project doesn't live at a fixed local
   path.
 
-- **No automatic GTK wrapping**: the lib still leaves binary wrapping
-  (`wrapGAppsHook3`, etc.) to consumers in a separate derivation. Adding it
-  to the shared inputs perturbs `PKG_CONFIG_PATH` and invalidates every
-  `-sys` crate fingerprint.
+- **Wrapping is a separate derivation**: `tauri.wrappedApp` wraps with
+  `wrapGAppsHook3` (Linux only). The hook never enters the cargo builds,
+  where its propagated inputs could perturb `PKG_CONFIG_PATH` and invalidate
+  every `-sys` crate fingerprint.

--- a/templates/default/flake.nix
+++ b/templates/default/flake.nix
@@ -64,10 +64,12 @@
         packages = {
           inherit frontend;
           default = tauri.app;
+          wrapped = tauri.wrappedApp;
         };
 
         checks = {
           inherit (tauri) app;
+          wrapped = tauri.wrappedApp;
 
           clippy = craneLib.cargoClippy (
             tauri.commonArgs


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by deepseek-v4-pro on behalf of @JPHutchins. JP asked whether the README on main lets a consumer (e.g. @ArtixBTW verifying the bundled output) understand what they get — this PR fills the gaps found in that audit.

- The **Minimal Example is annotated**: what the frontend derivation is for, what `buildTauriApp` wires up (appSrc/depsSrc split, artifact reuse, bundle-by-default), what `tauri.app` now contains (desktop entry, icons, binary on Linux; `.app` plus binary on macOS), and what `wrappedApp` does. The example also exposes `wrapped = tauri.wrappedApp;` in its packages.
- `tauri.app` Note reworded from "final binary package" to the bundled output description.
- The **"No automatic GTK wrapping" caveat was stale** — `wrappedApp` exists now; reworded to the real design (wrapping is a separate derivation so the hook never enters the cargo builds).
- `wrappedApp` Note tightened per the backlog finding `docs-overbroad-runtime-claim` (#21).
- The template flake exposes `wrappedApp` in packages and checks to match.

Docs-only; no derivation inputs change.